### PR TITLE
feat: tier II model-based source inversion (Gaussian + lognormal, Matérn-3/2 prior)

### DIFF
--- a/docs/design/02_tier2_lagrangian.md
+++ b/docs/design/02_tier2_lagrangian.md
@@ -193,8 +193,8 @@ When fusing across instruments, each observation tensor carries its own AK and f
 | 1 | Backward footprint | `plumax.lagrangian.footprint` | ✓ |
 | 1 | C-grid-aware wind interpolator | `plumax.lagrangian.wind_interp` | ☐ |
 | 1 | Column + AK pipeline | reuse `gauss_plume.observation` from Tier I | ☐ |
-| 2 | Likelihoods + spatial priors | `plumax.lagrangian.likelihoods` | ☐ |
-| 2 | Linear inversion (Gaussian / lognormal) | reuse [`assimilation/solve.py`](https://github.com/jejjohnson/plumax/tree/main/src/plumax/assimilation/solve.py) with $\tilde{\mathbf{F}}$ injected | ☐ |
+| 2 | Likelihoods + spatial priors (Matérn-3/2, R = R_retr + R_repr) | `plumax.lagrangian.inversion` | ✓ |
+| 2 | Linear inversion (Gaussian / lognormal closed form) | `plumax.lagrangian.inversion` (`linear_gaussian_inversion` / `lognormal_inversion`) | ✓ |
 | 2 | Krylov / structure-aware solver | dispatch to [`gaussx`](https://github.com/jejjohnson/gaussx) | dependency |
 | 2 | EKI | [`filterax`](https://github.com/jejjohnson/filterax) (external) | dependency |
 | 2 | Posterior export → Tier V | `plume_simulation.lagrangian.posterior_export` | ☐ |

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -79,7 +79,7 @@ The build order is roughly: **Prerequisites → Tier I → RTM stack (parallel) 
 Module-level status is tracked per tier. Quick overview:
 
 - **Tier I — Gaussian:** ✓ plume + puff forward models, ✓ MAP/MCMC inversion. Emulator + amortized predictor not yet started.
-- **Tier II — Lagrangian:** ☐ not started. No `gauss_flows`-style trajectory module yet.
+- **Tier II — Lagrangian:** 🚧 forward model + model-based inference in [`plumax.lagrangian`](https://github.com/jejjohnson/plumax/tree/main/src/plumax/lagrangian/): Markov-1 Langevin particles, turbulence (homogeneous + Hanna), forward residence-time concentration, backward footprint, and closed-form Gaussian / lognormal source inversion with a Matérn-3/2 prior. Footprint emulator + amortized predictor (Steps 3–5) not started.
 - **Tier III — Eulerian FV:** 🚧 [`les_fvm`](https://github.com/jejjohnson/plumax/tree/main/src/plumax/les_fvm/) advection/diffusion/dynamics implemented; [`assimilation`](https://github.com/jejjohnson/plumax/tree/main/src/plumax/assimilation/) cost/control/solve scaffolding present. 4D-Var loop not wired end-to-end.
 - **RTM stack:** 🚧 [`hapi_lut`](https://github.com/jejjohnson/plumax/tree/main/src/plumax/hapi_lut/) LUT generator + Beer–Lambert in place; [`radtran`](https://github.com/jejjohnson/plumax/tree/main/src/plumax/radtran/) instrument/SRF/forward modules present; [`matched_filter`](https://github.com/jejjohnson/plumax/tree/main/src/plumax/matched_filter/) detection pipeline in place. Optimal-estimation retrieval not wired; neural RTM not started.
 - **Tier IV — Coupled:** ☐ not started. Awaiting Tier I + RTM completion before assembling the coupled forward.

--- a/src/plumax/lagrangian/__init__.py
+++ b/src/plumax/lagrangian/__init__.py
@@ -5,7 +5,8 @@ plus an Ornstein–Uhlenbeck turbulent-velocity process. The bridge between the
 analytical Tier I (no real wind variability) and the Eulerian Tier III. See the
 [Tier II design doc](https://github.com/jejjohnson/plumax/blob/main/docs/design/02_tier2_lagrangian.md).
 
-This v1 implements **Step 1 (the forward model)**:
+This implements **Step 1 (the forward model)** and **Step 2 (model-based
+inference)**:
 
 - ``turbulence`` — ``HomogeneousTurbulence`` (well-mixed-exact) and Hanna (1982)
   Monin–Obukhov-similarity profiles.
@@ -14,20 +15,39 @@ This v1 implements **Step 1 (the forward model)**:
 - ``concentration`` — forward steady concentration field via residence-time
   binning (``simulate_lagrangian``).
 - ``footprint`` — backward source–receptor sensitivity (``compute_footprint``).
+- ``inversion`` — closed-form Gaussian and sign-constrained lognormal Bayesian
+  inversion of the source vector from observations, with a Matérn-3/2 spatial
+  prior (``linear_gaussian_inversion`` / ``lognormal_inversion``).
 
-Model-based inference, the footprint emulator and the amortized predictor
-(Steps 2–5) are not yet implemented.
+The footprint emulator and the amortized predictor (Steps 3–5) are not yet
+implemented.
 """
 
 from __future__ import annotations
 
-from plumax.lagrangian import concentration, footprint, particles, turbulence
+from plumax.lagrangian import (
+    concentration,
+    footprint,
+    inversion,
+    particles,
+    turbulence,
+)
 from plumax.lagrangian.concentration import bin_positions, simulate_lagrangian
 from plumax.lagrangian.footprint import compute_footprint
+from plumax.lagrangian.inversion import (
+    GaussianPosterior,
+    LognormalPosterior,
+    linear_gaussian_inversion,
+    lognormal_inversion,
+    matern32_covariance,
+    observation_covariance,
+)
 from plumax.lagrangian.particles import (
     ParticleState,
     integrate_particles,
     langevin_step,
+    n_steps_for_horizon,
+    step_durations,
     uniform_wind,
     wind_from_speed_direction,
 )
@@ -35,7 +55,9 @@ from plumax.lagrangian.turbulence import HomogeneousTurbulence, hanna_profiles
 
 
 __all__ = [
+    "GaussianPosterior",
     "HomogeneousTurbulence",
+    "LognormalPosterior",
     "ParticleState",
     "bin_positions",
     "compute_footprint",
@@ -43,9 +65,16 @@ __all__ = [
     "footprint",
     "hanna_profiles",
     "integrate_particles",
+    "inversion",
     "langevin_step",
+    "linear_gaussian_inversion",
+    "lognormal_inversion",
+    "matern32_covariance",
+    "n_steps_for_horizon",
+    "observation_covariance",
     "particles",
     "simulate_lagrangian",
+    "step_durations",
     "turbulence",
     "uniform_wind",
     "wind_from_speed_direction",

--- a/src/plumax/lagrangian/concentration.py
+++ b/src/plumax/lagrangian/concentration.py
@@ -23,6 +23,7 @@ import numpy as np
 
 from plumax.lagrangian.particles import (
     ParticleState,
+    n_steps_for_horizon,
     step_durations,
     uniform_wind,
     wind_from_speed_direction,
@@ -202,7 +203,7 @@ def _accumulate_residence(
     """Integrate the ensemble and accumulate per-cell residence time [s]."""
     from plumax.lagrangian.particles import langevin_step
 
-    n_steps = max(int(np.ceil(t_end / dt)), 0)
+    n_steps = n_steps_for_horizon(t_end, dt)
     keys = jax.random.split(key, n_steps)
     # Step start times and per-step durations. When ``t_end`` is not an exact
     # multiple of ``dt`` the final step is shortened to the remainder so the

--- a/src/plumax/lagrangian/footprint.py
+++ b/src/plumax/lagrangian/footprint.py
@@ -24,7 +24,12 @@ import jax.numpy as jnp
 import numpy as np
 
 from plumax.lagrangian.concentration import _cell_indices
-from plumax.lagrangian.particles import ParticleState, langevin_step, step_durations
+from plumax.lagrangian.particles import (
+    ParticleState,
+    langevin_step,
+    n_steps_for_horizon,
+    step_durations,
+)
 
 
 if TYPE_CHECKING:
@@ -104,7 +109,7 @@ def compute_footprint(
     state = ParticleState(position=pos0, velocity=vel0)
 
     xe, ye = jnp.asarray(x_edges), jnp.asarray(y_edges)
-    n_steps = max(int(np.ceil(t_back / dt)), 0)
+    n_steps = n_steps_for_horizon(t_back, dt)
     keys = jax.random.split(key, n_steps)
     # Per-step durations summing to exactly ``t_back``: the final step is
     # shortened to the remainder when ``t_back`` is not a multiple of ``dt``, so

--- a/src/plumax/lagrangian/inversion.py
+++ b/src/plumax/lagrangian/inversion.py
@@ -1,0 +1,310 @@
+"""Tier II — model-based inversion of the source vector from observations.
+
+Given a source–receptor sensitivity (footprint) matrix ``F`` — the linear map
+from a discretised emission field ``q`` to predicted observations
+``y_pred = F q`` (see :func:`plumax.lagrangian.compute_footprint`) — this module
+recovers a Bayesian posterior over ``q`` from observed column enhancements.
+
+Two estimators, both following the Tier II design note
+([design](https://github.com/jejjohnson/plumax/blob/main/docs/design/02_tier2_lagrangian.md#tier2-inference)):
+
+- :func:`linear_gaussian_inversion` — the closed-form Gaussian–Gaussian
+  (BLUE / Kalman) update for a Gaussian prior ``q ~ N(q_a, B)`` and Gaussian
+  likelihood ``y = F q + ε``, ``ε ~ N(0, R)``::
+
+      q* = q_a + B Fᵀ (F B Fᵀ + R)⁻¹ (y − F q_a)
+      P* = B − B Fᵀ (F B Fᵀ + R)⁻¹ F B
+
+- :func:`lognormal_inversion` — the sign-constrained ``log q ~ N(log q_a,
+  B_log)`` variant, linearised about ``log q_a`` (the design's recommended v1
+  prior). With the tangent-linear Jacobian ``F̃ = F · diag(q_a)`` the log-space
+  increment is the same BLUE update and ``q* = q_a · exp(δ*) ≥ 0``.
+
+The spatial prior is built with :func:`matern32_covariance` — a Matérn-3/2
+kernel with a real correlation length, as the design note insists (a diagonal
+``B`` produces single-cell-spike posteriors). The likelihood covariance is
+assembled by :func:`observation_covariance`, which adds the **representation
+error** to the retrieval error rather than using the retrieval error alone.
+
+The estimators solve the ``(n_obs × n_obs)`` innovation system, which is the
+efficient ordering when ``n_obs ≪ n_grid`` (the usual overpass regime). They
+are pure JAX, so they compose under ``jit`` / ``vmap`` and are differentiable
+through the posterior mean (e.g. for hyperparameter tuning of ``ℓ`` or ``σ``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+
+
+@dataclass(frozen=True)
+class GaussianPosterior:
+    """Closed-form Gaussian posterior over the source vector.
+
+    Attributes:
+        mean: Posterior mean emission field ``q*`` [same units as the prior
+            mean], shape ``(n_grid,)``.
+        covariance: Posterior covariance ``P*`` [units²], shape
+            ``(n_grid, n_grid)``.
+    """
+
+    mean: jax.Array
+    covariance: jax.Array
+
+    @property
+    def std(self) -> jax.Array:
+        """Posterior per-cell standard deviation ``sqrt(diag(P*))``."""
+        return jnp.sqrt(jnp.clip(jnp.diag(self.covariance), 0.0, None))
+
+
+def matern32_covariance(
+    coordinates: jax.Array,
+    *,
+    variance: float,
+    length_scale: float,
+) -> jax.Array:
+    """Build a Matérn-3/2 prior covariance over grid-cell coordinates.
+
+    The Matérn-3/2 kernel
+
+        k(r) = σ² (1 + √3 r / ℓ) exp(−√3 r / ℓ),   r = ‖xᵢ − xⱼ‖
+
+    gives a once-differentiable random field — smoother than the exponential
+    (AR(1) / Matérn-1/2) kernel but far less rigid than a squared-exponential.
+    It is the design note's recommended spatial prior for regional emission
+    inversions: a real correlation length ``ℓ`` regularises the posterior so
+    unresolved structure spreads over neighbouring cells instead of collapsing
+    into single-cell spikes.
+
+    Args:
+        coordinates: Cell-centre coordinates [m], shape ``(n_grid, n_dim)``
+            (1-D coordinates of shape ``(n_grid,)`` are accepted and promoted).
+        variance: Marginal prior variance ``σ²`` (per cell), ``> 0``.
+        length_scale: Correlation length ``ℓ`` [m], ``> 0``.
+
+    Returns:
+        The ``(n_grid, n_grid)`` covariance matrix, symmetric positive-definite.
+    """
+    if variance <= 0.0:
+        raise ValueError("matern32_covariance: `variance` must be > 0.")
+    if length_scale <= 0.0:
+        raise ValueError("matern32_covariance: `length_scale` must be > 0.")
+    coords = jnp.asarray(coordinates, dtype=float)
+    if coords.ndim == 1:
+        coords = coords[:, None]
+    diff = coords[:, None, :] - coords[None, :, :]
+    r = jnp.sqrt(jnp.sum(diff**2, axis=-1) + 1e-300)
+    scaled = jnp.sqrt(3.0) * r / length_scale
+    return variance * (1.0 + scaled) * jnp.exp(-scaled)
+
+
+def observation_covariance(
+    retrieval_variance: jax.Array,
+    *,
+    representation_variance: float | jax.Array = 0.0,
+) -> jax.Array:
+    """Assemble the diagonal observation-error covariance ``R``.
+
+    ``R = R_retr + R_repr``: the per-pixel L2 **retrieval** error plus a
+    **representation** error that accounts for model-vs-observation footprint
+    mismatch. The design note is explicit that omitting ``R_repr`` (using the
+    retrieval error alone) overweights the observations and yields overconfident
+    posteriors, so the representation term is a first-class argument here.
+
+    Args:
+        retrieval_variance: Per-observation retrieval variance ``σ²_retr``,
+            shape ``(n_obs,)``. Must be ``> 0``.
+        representation_variance: Representation variance ``σ²_repr`` added to
+            every observation — a scalar or a ``(n_obs,)`` array. Default ``0``.
+
+    Returns:
+        The diagonal of ``R``, shape ``(n_obs,)``.
+    """
+    retr = jnp.asarray(retrieval_variance, dtype=float)
+    if jnp.ndim(retr) != 1:
+        raise ValueError("observation_covariance: `retrieval_variance` must be 1-D.")
+    repr_ = jnp.asarray(representation_variance, dtype=float)
+    return retr + repr_
+
+
+def _blue_update(
+    jacobian: jax.Array,
+    innovation: jax.Array,
+    prior_cov: jax.Array,
+    obs_var: jax.Array,
+) -> tuple[jax.Array, jax.Array]:
+    """Solve the BLUE increment and posterior covariance via the innovation form.
+
+    Returns ``(increment, posterior_cov)`` where
+    ``increment = B Fᵀ (F B Fᵀ + R)⁻¹ innovation`` and
+    ``posterior_cov = B − B Fᵀ (F B Fᵀ + R)⁻¹ F B``. ``R`` is diagonal, given by
+    ``obs_var``. The ``(n_obs × n_obs)`` system is solved with a Cholesky factor
+    for symmetry and speed (the efficient ordering when ``n_obs ≪ n_grid``).
+    """
+    bft = prior_cov @ jacobian.T  # B Fᵀ, (n_grid, n_obs)
+    s = jacobian @ bft  # F B Fᵀ, (n_obs, n_obs)
+    s = s + jnp.diag(obs_var)  # + R
+    # Symmetrise to kill round-off asymmetry before the Cholesky solve.
+    s = 0.5 * (s + s.T)
+    chol = jax.scipy.linalg.cho_factor(s, lower=True)
+    gain_t = jax.scipy.linalg.cho_solve(chol, bft.T)  # (F B Fᵀ + R)⁻¹ F B
+    increment = bft @ jax.scipy.linalg.cho_solve(chol, innovation)
+    posterior_cov = prior_cov - bft @ gain_t
+    posterior_cov = 0.5 * (posterior_cov + posterior_cov.T)
+    return increment, posterior_cov
+
+
+def linear_gaussian_inversion(
+    footprint: jax.Array,
+    observation: jax.Array,
+    *,
+    prior_mean: jax.Array,
+    prior_cov: jax.Array,
+    obs_variance: jax.Array,
+) -> GaussianPosterior:
+    """Closed-form Gaussian–Gaussian (BLUE) inversion of the source vector.
+
+    For a Gaussian prior ``q ~ N(q_a, B)`` and Gaussian likelihood
+    ``y = F q + ε``, ``ε ~ N(0, R)`` (``R`` diagonal), returns the exact
+    posterior ``N(q*, P*)`` with::
+
+        q* = q_a + B Fᵀ (F B Fᵀ + R)⁻¹ (y − F q_a)
+        P* = B − B Fᵀ (F B Fᵀ + R)⁻¹ F B
+
+    Args:
+        footprint: Source–receptor matrix ``F``, shape ``(n_obs, n_grid)``.
+        observation: Observed values ``y``, shape ``(n_obs,)``.
+        prior_mean: Prior mean ``q_a``, shape ``(n_grid,)``.
+        prior_cov: Prior covariance ``B``, shape ``(n_grid, n_grid)`` (e.g. from
+            :func:`matern32_covariance`).
+        obs_variance: Diagonal of ``R``, shape ``(n_obs,)`` (e.g. from
+            :func:`observation_covariance`).
+
+    Returns:
+        The :class:`GaussianPosterior` over ``q``.
+    """
+    f = jnp.asarray(footprint, dtype=float)
+    y = jnp.asarray(observation, dtype=float)
+    qa = jnp.asarray(prior_mean, dtype=float)
+    b = jnp.asarray(prior_cov, dtype=float)
+    r = jnp.asarray(obs_variance, dtype=float)
+    _check_inversion_shapes(f, y, qa, b, r)
+
+    innovation = y - f @ qa
+    increment, posterior_cov = _blue_update(f, innovation, b, r)
+    return GaussianPosterior(mean=qa + increment, covariance=posterior_cov)
+
+
+@dataclass(frozen=True)
+class LognormalPosterior:
+    """Linearised lognormal posterior over a non-negative source vector.
+
+    Attributes:
+        mean: Posterior mean emission field ``q* = q_a · exp(δ*) ≥ 0``, shape
+            ``(n_grid,)``.
+        log_increment: Log-space MAP increment ``δ* = log(q*/q_a)``, shape
+            ``(n_grid,)``.
+        log_covariance: Posterior covariance in log-space ``P*_log``, shape
+            ``(n_grid, n_grid)``.
+    """
+
+    mean: jax.Array
+    log_increment: jax.Array
+    log_covariance: jax.Array
+
+
+def lognormal_inversion(
+    footprint: jax.Array,
+    observation: jax.Array,
+    *,
+    prior_mean: jax.Array,
+    prior_log_cov: jax.Array,
+    obs_variance: jax.Array,
+) -> LognormalPosterior:
+    """Sign-constrained inversion via a lognormal prior linearised in log-space.
+
+    With ``log q ~ N(log q_a, B_log)`` and the forward linearised about the
+    prior mean, the tangent-linear Jacobian is ``F̃ = F · diag(q_a)`` and the
+    log-space increment ``δ = log(q / q_a)`` follows the same BLUE update::
+
+        δ* = B_log F̃ᵀ (F̃ B_log F̃ᵀ + R)⁻¹ (y − F q_a)
+        q* = q_a · exp(δ*)          (≥ 0 by construction)
+
+    This is the design note's recommended v1 prior: it enforces non-negative
+    emissions while keeping the update closed-form (no projected-gradient or
+    NNLS inner loop). The innovation ``y − F q_a`` is the observation minus the
+    forward evaluated at the prior mean (``δ = 0 ⇒ q = q_a``).
+
+    Args:
+        footprint: Source–receptor matrix ``F``, shape ``(n_obs, n_grid)``.
+        observation: Observed values ``y``, shape ``(n_obs,)``.
+        prior_mean: Prior median emission field ``q_a > 0``, shape
+            ``(n_grid,)``.
+        prior_log_cov: Log-space prior covariance ``B_log``, shape
+            ``(n_grid, n_grid)``.
+        obs_variance: Diagonal of ``R``, shape ``(n_obs,)``.
+
+    Returns:
+        The :class:`LognormalPosterior` over ``q``.
+    """
+    f = jnp.asarray(footprint, dtype=float)
+    y = jnp.asarray(observation, dtype=float)
+    qa = jnp.asarray(prior_mean, dtype=float)
+    b_log = jnp.asarray(prior_log_cov, dtype=float)
+    r = jnp.asarray(obs_variance, dtype=float)
+    _check_inversion_shapes(f, y, qa, b_log, r)
+    if bool(jnp.any(qa <= 0.0)):
+        raise ValueError("lognormal_inversion: `prior_mean` (q_a) must be > 0.")
+
+    jac_tilde = f * qa[None, :]  # F̃ = F diag(q_a), (n_obs, n_grid)
+    innovation = y - f @ qa
+    log_increment, log_cov = _blue_update(jac_tilde, innovation, b_log, r)
+    mean = qa * jnp.exp(log_increment)
+    return LognormalPosterior(
+        mean=mean, log_increment=log_increment, log_covariance=log_cov
+    )
+
+
+def _check_inversion_shapes(
+    footprint: jax.Array,
+    observation: jax.Array,
+    prior_mean: jax.Array,
+    prior_cov: jax.Array,
+    obs_variance: jax.Array,
+) -> None:
+    if footprint.ndim != 2:
+        raise ValueError("inversion: `footprint` must be 2-D (n_obs, n_grid).")
+    n_obs, n_grid = footprint.shape
+    if observation.shape != (n_obs,):
+        raise ValueError(
+            f"inversion: `observation` must have shape ({n_obs},), "
+            f"got {observation.shape}."
+        )
+    if prior_mean.shape != (n_grid,):
+        raise ValueError(
+            f"inversion: `prior_mean` must have shape ({n_grid},), "
+            f"got {prior_mean.shape}."
+        )
+    if prior_cov.shape != (n_grid, n_grid):
+        raise ValueError(
+            f"inversion: prior covariance must have shape ({n_grid}, {n_grid}), "
+            f"got {prior_cov.shape}."
+        )
+    if obs_variance.shape != (n_obs,):
+        raise ValueError(
+            f"inversion: `obs_variance` must have shape ({n_obs},), "
+            f"got {obs_variance.shape}."
+        )
+
+
+__all__ = [
+    "GaussianPosterior",
+    "LognormalPosterior",
+    "linear_gaussian_inversion",
+    "lognormal_inversion",
+    "matern32_covariance",
+    "observation_covariance",
+]

--- a/src/plumax/lagrangian/inversion.py
+++ b/src/plumax/lagrangian/inversion.py
@@ -40,6 +40,17 @@ import jax
 import jax.numpy as jnp
 
 
+def _is_traced(*values: object) -> bool:
+    """Return ``True`` if any value is a JAX tracer (i.e. we're inside a transform).
+
+    Used to skip the eager value-validation ``if`` checks under ``jit`` / ``grad``
+    / ``vmap``, where converting a traced scalar to a Python ``bool`` would raise
+    ``TracerBoolConversionError``. Validation still runs for concrete inputs, so
+    ordinary callers keep the helpful error messages.
+    """
+    return any(isinstance(v, jax.core.Tracer) for v in values)
+
+
 @dataclass(frozen=True)
 class GaussianPosterior:
     """Closed-form Gaussian posterior over the source vector.
@@ -88,10 +99,14 @@ def matern32_covariance(
     Returns:
         The ``(n_grid, n_grid)`` covariance matrix, symmetric positive-definite.
     """
-    if variance <= 0.0:
-        raise ValueError("matern32_covariance: `variance` must be > 0.")
-    if length_scale <= 0.0:
-        raise ValueError("matern32_covariance: `length_scale` must be > 0.")
+    # Validate eagerly for concrete inputs; skip under jit/grad/vmap (the doc
+    # advertises gradient-based tuning of variance / length_scale, where these
+    # would be tracers and a Python ``<=`` test would raise).
+    if not _is_traced(variance, length_scale):
+        if variance <= 0.0:
+            raise ValueError("matern32_covariance: `variance` must be > 0.")
+        if length_scale <= 0.0:
+            raise ValueError("matern32_covariance: `length_scale` must be > 0.")
     coords = jnp.asarray(coordinates, dtype=float)
     if coords.ndim == 1:
         coords = coords[:, None]
@@ -256,7 +271,10 @@ def lognormal_inversion(
     b_log = jnp.asarray(prior_log_cov, dtype=float)
     r = jnp.asarray(obs_variance, dtype=float)
     _check_inversion_shapes(f, y, qa, b_log, r)
-    if bool(jnp.any(qa <= 0.0)):
+    # Eager positivity check; skipped under jit/vmap over `prior_mean` (where a
+    # host-bool conversion would raise). The lognormal form q = q_a·exp(δ)
+    # implicitly assumes q_a > 0; a non-positive concrete q_a is a usage error.
+    if not _is_traced(prior_mean) and bool(jnp.any(qa <= 0.0)):
         raise ValueError("lognormal_inversion: `prior_mean` (q_a) must be > 0.")
 
     jac_tilde = f * qa[None, :]  # F̃ = F diag(q_a), (n_obs, n_grid)

--- a/src/plumax/lagrangian/particles.py
+++ b/src/plumax/lagrangian/particles.py
@@ -136,14 +136,34 @@ def langevin_step(
     return ParticleState(position=pos_new, velocity=vel_new)
 
 
+def n_steps_for_horizon(horizon: float, dt: float, *, rtol: float = 1e-9) -> int:
+    """Number of fixed-``dt`` steps covering ``horizon`` (ceil, float-robust).
+
+    Plain ``ceil(horizon / dt)`` adds a spurious extra step when the quotient is
+    mathematically an integer but floating-point rounds it just above (e.g.
+    ``2.1 / 0.15 → 14.000…02``). Snapping the quotient to the nearest integer
+    when it is within ``rtol`` avoids that degenerate final zero-length step.
+    Returns 0 for a non-positive horizon.
+    """
+    if horizon <= 0.0:
+        return 0
+    quotient = horizon / dt
+    nearest = round(quotient)
+    if abs(quotient - nearest) <= rtol * max(1.0, abs(nearest)):
+        return max(int(nearest), 1)
+    return int(np.ceil(quotient))
+
+
 def step_durations(horizon: float, dt: float, n_steps: int) -> jax.Array:
     """Per-step durations summing to ``horizon``; the final step takes the rest.
 
     All steps are ``dt`` except the last, which is the remainder
     ``horizon - (n_steps - 1) * dt`` (equal to ``dt`` when ``horizon`` is an
-    exact multiple). Returns an empty array when ``n_steps == 0``. Used by the
-    integrator / residence / footprint paths so a non-divisible horizon advances
-    over exactly ``horizon`` rather than ``n_steps * dt``.
+    exact multiple). Returns an empty array when ``n_steps == 0``. Pair with
+    :func:`n_steps_for_horizon` so the final duration is always ``> 0`` (no
+    degenerate zero-length step from float round-up). Used by the integrator /
+    residence / footprint paths so a non-divisible horizon advances over exactly
+    ``horizon`` rather than ``n_steps * dt``.
     """
     if n_steps == 0:
         return jnp.zeros((0,))
@@ -182,7 +202,7 @@ def integrate_particles(
         ``(final_state, trajectory)`` where ``trajectory`` is ``None`` unless
         ``save_trajectory`` is set.
     """
-    n_steps = max(int(np.ceil((t1 - t0) / dt)), 0)
+    n_steps = n_steps_for_horizon(t1 - t0, dt)
     keys = jax.random.split(key, n_steps)
     # Step start times and per-step durations. When ``t1 - t0`` is not an exact
     # multiple of ``dt`` the final step is shortened to the remainder so the

--- a/tests/lagrangian/test_inversion.py
+++ b/tests/lagrangian/test_inversion.py
@@ -268,3 +268,64 @@ def test_inversion_is_jittable():
 
     out = mean_of(yj)
     assert out.shape == (n_grid,)
+
+
+def test_lognormal_inversion_is_jittable_over_prior_mean():
+    # The eager q_a > 0 check must be skipped under tracing — jitting with
+    # prior_mean as a traced array argument must not raise
+    # TracerBoolConversionError (regression for the Codex/Copilot P2).
+    import jax
+
+    coords, f, _ = _toy_problem()
+    n_obs, n_grid = f.shape
+    b_log = matern32_covariance(coords, variance=0.25, length_scale=300.0)
+    r = observation_covariance(np.full(n_obs, 1e-3))
+    fj = jnp.asarray(f)
+
+    @jax.jit
+    def mean_of(qa):
+        y = fj @ qa
+        return lognormal_inversion(
+            fj, y, prior_mean=qa, prior_log_cov=b_log, obs_variance=r
+        ).mean
+
+    out = mean_of(jnp.full(n_grid, 1.2))
+    assert out.shape == (n_grid,)
+    assert np.all(np.asarray(out) > 0.0)
+
+
+def test_lognormal_inversion_is_vmappable_over_prior_mean():
+    import jax
+
+    coords, f, _ = _toy_problem()
+    n_obs, n_grid = f.shape
+    b_log = matern32_covariance(coords, variance=0.25, length_scale=300.0)
+    r = observation_covariance(np.full(n_obs, 1e-3))
+    fj = jnp.asarray(f)
+
+    def mean_of(qa):
+        return lognormal_inversion(
+            fj, fj @ qa, prior_mean=qa, prior_log_cov=b_log, obs_variance=r
+        ).mean
+
+    qas = jnp.stack([jnp.full(n_grid, 1.0), jnp.full(n_grid, 1.5)])
+    out = jax.vmap(mean_of)(qas)
+    assert out.shape == (2, n_grid)
+
+
+def test_matern32_differentiable_through_length_scale():
+    # The prior must support gradient-based hyperparameter tuning: grad over
+    # length_scale must not trip the eager positivity check.
+    import jax
+
+    coords = jnp.linspace(0.0, 1000.0, 8)
+
+    def trace_of_cov(length_scale):
+        return jnp.trace(
+            matern32_covariance(coords, variance=1.0, length_scale=length_scale)
+        )
+
+    g = jax.grad(trace_of_cov)(250.0)
+    # trace = n·σ² is independent of ℓ, so its gradient is exactly 0 — the point
+    # is that grad evaluates at all (no TracerBoolConversionError).
+    assert np.isfinite(float(g))

--- a/tests/lagrangian/test_inversion.py
+++ b/tests/lagrangian/test_inversion.py
@@ -1,0 +1,270 @@
+"""Tests for the Tier II model-based source inversion."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from plumax.lagrangian.inversion import (
+    GaussianPosterior,
+    LognormalPosterior,
+    linear_gaussian_inversion,
+    lognormal_inversion,
+    matern32_covariance,
+    observation_covariance,
+)
+
+
+# ── Matérn-3/2 prior ─────────────────────────────────────────────────────────
+
+
+def test_matern32_is_spd_with_unit_diagonal_variance():
+    coords = np.linspace(0.0, 1000.0, 12)
+    b = np.asarray(matern32_covariance(coords, variance=4.0, length_scale=200.0))
+    # Symmetric.
+    np.testing.assert_allclose(b, b.T, atol=1e-12)
+    # Diagonal equals the marginal variance (r = 0 → k = σ²).
+    np.testing.assert_allclose(np.diag(b), 4.0, atol=1e-10)
+    # Positive-definite.
+    assert np.all(np.linalg.eigvalsh(b) > 0.0)
+
+
+def test_matern32_decays_with_distance():
+    coords = np.linspace(0.0, 1000.0, 6)
+    b = np.asarray(matern32_covariance(coords, variance=1.0, length_scale=150.0))
+    # Correlation to cell 0 is monotone non-increasing with separation.
+    row = b[0]
+    assert np.all(np.diff(row) <= 1e-12)
+
+
+def test_matern32_longer_length_scale_is_more_correlated():
+    coords = np.linspace(0.0, 1000.0, 6)
+    short = np.asarray(matern32_covariance(coords, variance=1.0, length_scale=100.0))
+    long = np.asarray(matern32_covariance(coords, variance=1.0, length_scale=400.0))
+    # At a fixed separation the longer length-scale keeps more correlation.
+    assert long[0, -1] > short[0, -1]
+
+
+def test_matern32_validates_positive_hyperparameters():
+    coords = np.linspace(0.0, 1.0, 4)
+    with pytest.raises(ValueError, match="variance"):
+        matern32_covariance(coords, variance=0.0, length_scale=1.0)
+    with pytest.raises(ValueError, match="length_scale"):
+        matern32_covariance(coords, variance=1.0, length_scale=0.0)
+
+
+# ── Observation covariance ──────────────────────────────────────────────────
+
+
+def test_observation_covariance_adds_representation_error():
+    retr = np.array([1.0, 2.0, 3.0])
+    r = np.asarray(observation_covariance(retr, representation_variance=0.5))
+    np.testing.assert_allclose(r, [1.5, 2.5, 3.5])
+
+
+def test_observation_covariance_defaults_to_retrieval_only():
+    retr = np.array([1.0, 2.0])
+    np.testing.assert_allclose(np.asarray(observation_covariance(retr)), retr)
+
+
+# ── Linear Gaussian inversion ───────────────────────────────────────────────
+
+
+def _toy_problem(n_grid=8, n_obs=12, seed=0):
+    rng = np.random.default_rng(seed)
+    coords = np.linspace(0.0, 1000.0, n_grid)
+    f = rng.uniform(0.0, 1.0, size=(n_obs, n_grid))
+    q_true = rng.uniform(0.5, 2.0, size=n_grid)
+    return coords, f, q_true
+
+
+def test_linear_inversion_recovers_truth_low_noise():
+    # Twin experiment: synthesise obs from a known source, invert, recover it.
+    coords, f, q_true = _toy_problem()
+    n_obs, n_grid = f.shape
+    y = f @ q_true  # noiseless observations
+    b = matern32_covariance(coords, variance=1.0, length_scale=300.0)
+    r = observation_covariance(np.full(n_obs, 1e-6))
+    post = linear_gaussian_inversion(
+        f, y, prior_mean=np.full(n_grid, 1.0), prior_cov=b, obs_variance=r
+    )
+    assert isinstance(post, GaussianPosterior)
+    # Tight likelihood → posterior mean tracks the truth closely.
+    np.testing.assert_allclose(np.asarray(post.mean), q_true, rtol=5e-2, atol=5e-2)
+
+
+def test_linear_inversion_returns_to_prior_when_obs_uninformative():
+    coords, f, _ = _toy_problem()
+    n_obs, n_grid = f.shape
+    qa = np.full(n_grid, 1.3)
+    y = f @ qa  # innovation is exactly zero
+    b = matern32_covariance(coords, variance=1.0, length_scale=300.0)
+    r = observation_covariance(np.full(n_obs, 1e3))  # very loose
+    post = linear_gaussian_inversion(f, y, prior_mean=qa, prior_cov=b, obs_variance=r)
+    # Zero innovation → posterior mean stays at the prior mean.
+    np.testing.assert_allclose(np.asarray(post.mean), qa, atol=1e-6)
+
+
+def test_linear_inversion_reduces_variance():
+    coords, f, q_true = _toy_problem()
+    n_obs, n_grid = f.shape
+    y = f @ q_true
+    b = np.asarray(matern32_covariance(coords, variance=1.0, length_scale=300.0))
+    r = observation_covariance(np.full(n_obs, 1e-2))
+    post = linear_gaussian_inversion(
+        f, y, prior_mean=np.full(n_grid, 1.0), prior_cov=b, obs_variance=r
+    )
+    # Observing data cannot increase the posterior variance over the prior.
+    assert np.all(np.asarray(post.std) <= np.sqrt(np.diag(b)) + 1e-8)
+    # Posterior covariance stays symmetric PSD.
+    p = np.asarray(post.covariance)
+    np.testing.assert_allclose(p, p.T, atol=1e-9)
+    assert np.min(np.linalg.eigvalsh(p)) > -1e-8
+
+
+def test_linear_inversion_shape_validation():
+    coords, f, q_true = _toy_problem()
+    n_obs, n_grid = f.shape
+    b = matern32_covariance(coords, variance=1.0, length_scale=300.0)
+    r = observation_covariance(np.full(n_obs, 1.0))
+    with pytest.raises(ValueError, match="observation"):
+        linear_gaussian_inversion(
+            f, np.zeros(n_obs + 1), prior_mean=q_true, prior_cov=b, obs_variance=r
+        )
+    with pytest.raises(ValueError, match="prior_mean"):
+        linear_gaussian_inversion(
+            f,
+            f @ q_true,
+            prior_mean=np.zeros(n_grid + 1),
+            prior_cov=b,
+            obs_variance=r,
+        )
+
+
+# ── Lognormal (sign-constrained) inversion ──────────────────────────────────
+
+
+def test_lognormal_inversion_is_nonnegative_and_recovers_truth():
+    # The linear-in-log estimator is valid for *moderate* enhancements over the
+    # prior, so the twin truth is a small (≤ ~15 %) perturbation of q_a.
+    coords, f, _ = _toy_problem()
+    n_obs, n_grid = f.shape
+    rng = np.random.default_rng(11)
+    qa = np.full(n_grid, 1.0)
+    q_true = qa * np.exp(rng.uniform(-0.15, 0.15, size=n_grid))
+    y = f @ q_true
+    b_log = matern32_covariance(coords, variance=0.25, length_scale=300.0)
+    r = observation_covariance(np.full(n_obs, 1e-6))
+    post = lognormal_inversion(f, y, prior_mean=qa, prior_log_cov=b_log, obs_variance=r)
+    assert isinstance(post, LognormalPosterior)
+    # Non-negativity is guaranteed by q = q_a · exp(δ).
+    assert np.all(np.asarray(post.mean) >= 0.0)
+    # Linearised about the prior, so it tracks a moderate-enhancement truth.
+    np.testing.assert_allclose(np.asarray(post.mean), q_true, rtol=0.1, atol=0.05)
+
+
+def test_lognormal_inversion_strictly_positive_under_large_negative_increment():
+    # Even when the data push δ strongly negative, q = q_a · exp(δ) stays > 0
+    # (the property a Gaussian inversion on q would violate by going negative).
+    coords, f, _ = _toy_problem()
+    n_obs, n_grid = f.shape
+    qa = np.full(n_grid, 1.0)
+    # Observations consistent with a near-zero source → large negative δ.
+    y = f @ (qa * 0.05)
+    b_log = matern32_covariance(coords, variance=1.0, length_scale=300.0)
+    r = observation_covariance(np.full(n_obs, 1e-6))
+    post = lognormal_inversion(f, y, prior_mean=qa, prior_log_cov=b_log, obs_variance=r)
+    assert np.all(np.asarray(post.mean) > 0.0)
+
+
+def test_lognormal_inversion_rejects_nonpositive_prior_mean():
+    coords, f, _ = _toy_problem()
+    n_obs, n_grid = f.shape
+    b_log = matern32_covariance(coords, variance=0.25, length_scale=300.0)
+    r = observation_covariance(np.full(n_obs, 1.0))
+    qa = np.full(n_grid, 1.0)
+    qa[0] = 0.0
+    with pytest.raises(ValueError, match="q_a"):
+        lognormal_inversion(
+            f, np.zeros(n_obs), prior_mean=qa, prior_log_cov=b_log, obs_variance=r
+        )
+
+
+def test_lognormal_zero_innovation_returns_prior_mean():
+    coords, f, _ = _toy_problem()
+    n_obs, n_grid = f.shape
+    qa = np.full(n_grid, 1.2)
+    y = f @ qa  # innovation zero → δ* = 0 → q* = q_a
+    b_log = matern32_covariance(coords, variance=0.25, length_scale=300.0)
+    r = observation_covariance(np.full(n_obs, 1.0))
+    post = lognormal_inversion(f, y, prior_mean=qa, prior_log_cov=b_log, obs_variance=r)
+    np.testing.assert_allclose(np.asarray(post.log_increment), 0.0, atol=1e-8)
+    np.testing.assert_allclose(np.asarray(post.mean), qa, rtol=1e-6)
+
+
+def test_inversion_with_real_footprint_matrix():
+    # End-to-end: build F from actual backward footprints (one row per
+    # receptor), synthesise observations from a known surface source, and
+    # recover it. Exercises the full footprint → inversion handoff.
+    from plumax.lagrangian.footprint import compute_footprint
+    from plumax.lagrangian.particles import wind_from_speed_direction
+    from plumax.lagrangian.turbulence import HomogeneousTurbulence
+
+    turb = HomogeneousTurbulence.isotropic(sigma=0.6, tau=30.0)
+    wind = wind_from_speed_direction(4.0, 270.0)  # from west → flows east
+    domain_x = (-100.0, 500.0, 12)
+    domain_y = (-200.0, 200.0, 8)
+    receptors = [(300.0, 0.0, 20.0), (350.0, 50.0, 20.0), (250.0, -50.0, 20.0)]
+
+    rows, xc, yc = [], None, None
+    for r in receptors:
+        fp, xc, yc = compute_footprint(
+            r,
+            turb,
+            domain_x=domain_x,
+            domain_y=domain_y,
+            wind=wind,
+            n_particles=2000,
+            t_back=150.0,
+            dt=1.0,
+            seed=0,
+        )
+        rows.append(np.asarray(fp).reshape(-1))
+    f = np.stack(rows, axis=0)  # (n_obs, n_grid)
+    n_obs, n_grid = f.shape
+
+    # Coordinates for the Matérn prior over the flattened (x, y) surface grid.
+    gx, gy = np.meshgrid(xc, yc, indexing="ij")
+    coords = np.column_stack([gx.reshape(-1), gy.reshape(-1)])
+
+    q_true = np.full(n_grid, 0.1)
+    q_true[n_grid // 2] = 1.0  # a localised hot-spot
+    y = f @ q_true
+
+    b = matern32_covariance(coords, variance=1.0, length_scale=150.0)
+    r = observation_covariance(np.full(n_obs, 1e-8))
+    post = linear_gaussian_inversion(
+        f, y, prior_mean=np.full(n_grid, 0.1), prior_cov=b, obs_variance=r
+    )
+    # The inversion reproduces the observations it was given (data consistency).
+    np.testing.assert_allclose(np.asarray(f @ post.mean), y, rtol=1e-3, atol=1e-3)
+
+
+def test_inversion_is_jittable():
+    import jax
+
+    coords, f, q_true = _toy_problem()
+    n_obs, n_grid = f.shape
+    b = matern32_covariance(coords, variance=1.0, length_scale=300.0)
+    r = observation_covariance(np.full(n_obs, 1e-3))
+    fj, yj, qaj = jnp.asarray(f), jnp.asarray(f @ q_true), jnp.ones(n_grid)
+
+    @jax.jit
+    def mean_of(y):
+        return linear_gaussian_inversion(
+            fj, y, prior_mean=qaj, prior_cov=b, obs_variance=r
+        ).mean
+
+    out = mean_of(yj)
+    assert out.shape == (n_grid,)

--- a/tests/lagrangian/test_particles.py
+++ b/tests/lagrangian/test_particles.py
@@ -11,11 +11,38 @@ from plumax.lagrangian.particles import (
     ParticleState,
     integrate_particles,
     langevin_step,
+    n_steps_for_horizon,
     step_durations,
     uniform_wind,
     wind_from_speed_direction,
 )
 from plumax.lagrangian.turbulence import HomogeneousTurbulence
+
+
+@pytest.mark.parametrize(
+    "horizon,dt,expected",
+    [
+        (10.0, 1.0, 10),  # exact
+        (10.1, 1.0, 11),  # genuine partial step
+        (0.5, 1.0, 1),  # sub-step horizon
+        (0.0, 1.0, 0),  # empty
+        (2.1, 0.15, 14),  # float round-up trap: 2.1/0.15 = 14.000…02, not 15
+        (1.0, 0.1, 10),  # 1.0/0.1 = 9.999… in float, must snap to 10
+    ],
+)
+def test_n_steps_for_horizon_is_float_robust(horizon, dt, expected):
+    assert n_steps_for_horizon(horizon, dt) == expected
+
+
+def test_n_steps_no_zero_length_final_step_on_rounded_multiple():
+    # The P3 case: 2.1 is an exact multiple of 0.15 (×14) but the float quotient
+    # rounds just above 14, so a naive ceil would add a 15th, zero-length step.
+    n = n_steps_for_horizon(2.1, 0.15)
+    dts = np.asarray(step_durations(2.1, 0.15, n))
+    assert dts.size == 14
+    assert np.all(dts > 0.0)  # no degenerate zero-length step
+    np.testing.assert_allclose(dts, 0.15, atol=1e-9)
+    assert dts.sum() == pytest.approx(2.1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Implements **Tier II Step 2 — model-based inference** from the
[Tier II design note](https://github.com/jejjohnson/plumax/blob/main/docs/design/02_tier2_lagrangian.md#tier2-inference),
on top of the forward model (particles / turbulence / concentration / footprint)
that merged in #7. New module: `plumax.lagrangian.inversion`.

Given a source–receptor footprint matrix `F` (from `compute_footprint`), it
recovers a Bayesian posterior over the emission field `q` from observed column
enhancements.

### What's included

- **`matern32_covariance`** — Matérn-3/2 spatial prior with a real correlation
  length. The design note insists on this (a diagonal `B` produces single-cell
  spike posteriors); the existing `assimilation.background` only had
  AR(1)/Matérn-1/2.
- **`observation_covariance`** — assembles `R = R_retr + R_repr`, making the
  **representation error** a first-class term rather than retrieval-error-only
  (the note flags retrieval-only `R` as producing overconfident posteriors).
- **`linear_gaussian_inversion`** — closed-form Gaussian–Gaussian (BLUE)
  posterior:

  ```
  q* = q_a + B Fᵀ (F B Fᵀ + R)⁻¹ (y − F q_a)
  P* = B − B Fᵀ (F B Fᵀ + R)⁻¹ F B
  ```

  solved in the `(n_obs × n_obs)` innovation form via Cholesky.
- **`lognormal_inversion`** — sign-constrained `log q ~ N(log q_a, B_log)`
  linearised about the prior (`F̃ = F·diag(q_a)`), giving `q* = q_a·exp(δ*) ≥ 0`
  by construction — the note's recommended v1 prior.

All pure-JAX: `jit`/`vmap`-friendly and differentiable through the posterior
mean (e.g. for hyperparameter tuning of `ℓ`, `σ`).

### Also (Codex P3 follow-up from #7)

`#7` merged with one open P3: `step_durations` could emit a zero-length final
step when the horizon is a float that rounds just above an exact `dt` multiple
(e.g. `2.1/0.15`). Added **`n_steps_for_horizon`** — an epsilon-tolerant step
count — and routed `integrate_particles` / residence / footprint through it.

### Tests

23 new tests: Matérn-3/2 properties (SPD, decay, length-scale monotonicity),
`R` assembly, twin-experiment recovery, variance reduction + PSD posterior,
lognormal positivity (incl. large-negative-increment), an **end-to-end inversion
driven by real `compute_footprint` matrices**, jittability, and the
`n_steps_for_horizon` float-robustness cases.

## Status

- ✅ `pytest`: **445 passed**, 1 skipped — **coverage 91%** (gate: 80%)
- ✅ `ruff check` + `ruff format --check` + `ty check` clean

## Notes

- Scoped to the design's "dense-solver limit (≲10k cells × ≲1k obs)"; the
  Krylov / structure-aware (`gaussx` Kronecker) and EKI (`filterax`) paths for
  larger grids remain future work, as do the footprint emulator and amortized
  predictor (Steps 3–5).