### PR TITLE
chore: gitignore Claude Code agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ venv.bak/
 
 # Plans (tracked via GitHub issues, not committed)
 .plans/
+
+# Claude Code agent worktrees (transient, auto-cleaned)
+.claude/worktrees/


### PR DESCRIPTION
`.claude/worktrees/` holds transient, auto-cleaned agent worktrees (created when running parallel agents in isolated worktrees) and must never be tracked. Ignoring it keeps the repo tree clean — otherwise it shows up as untracked and trips the stop-hook git check.

One-line `.gitignore` addition; no code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqbaYdcfhG7AmuEaxgAAr6)_