### PR TITLE
fix(les_fvm): boundary-condition docs, wind staggering, CFL guard, 4D-Var convergence (epic #19)

### DIFF
--- a/src/plumax/les_fvm/__init__.py
+++ b/src/plumax/les_fvm/__init__.py
@@ -65,7 +65,10 @@ from plumax.les_fvm.grid import (
     PlumeGrid3D,
     make_grid,
 )
-from plumax.les_fvm.simulate import simulate_eulerian_dispersion
+from plumax.les_fvm.simulate import (
+    simulate_eulerian_dispersion,
+    stable_step_bound,
+)
 from plumax.les_fvm.source import (
     GaussianSource,
     make_gaussian_source,
@@ -112,6 +115,7 @@ __all__ = [
     "simulate_eulerian_dispersion",
     "solve_4dvar",
     "source",
+    "stable_step_bound",
     "uniform_wind_field",
     "wind",
     "wind_field_from_callable",

--- a/src/plumax/les_fvm/boundary.py
+++ b/src/plumax/les_fvm/boundary.py
@@ -63,12 +63,13 @@ class VerticalBC(eqx.Module):
         Ground-boundary behaviour.
     bottom_value : float, default 0.0
         For ``dirichlet``: the boundary value.
-        For ``neumann``: the *outward-normal* gradient ``∂C/∂n`` — i.e.
-        the gradient along ``-z`` at the bottom face (a positive value
-        means ``C`` increases as you move downward out of the domain).
-        Ignored for ``outflow`` / ``periodic``.
-    top_kind, top_value : same, but Neumann ``value`` is the outward-normal
-        gradient along ``+z``.
+        For ``neumann``: the coordinate gradient ``∂C/∂z`` along ``+z``
+        at the face — a positive value means ``C`` increases with height.
+        The ghost cell is set so the finite-difference ``∂C/∂z`` across
+        the face equals ``value``. Ignored for ``outflow`` / ``periodic``.
+    top_kind, top_value : same, with the Neumann ``value`` again the
+        coordinate gradient ``∂C/∂z`` along ``+z`` (same convention on
+        both faces; see the sign note in :func:`_apply_vertical_face`).
     """
 
     bottom_kind: VerticalBCKind = eqx.field(static=True)
@@ -83,8 +84,8 @@ class VerticalBC(eqx.Module):
     ) -> Float[Array, "Nz Ny Nx"]:
         """Return ``field`` with top and bottom ghost slices updated.
 
-        ``dz`` is required to translate a Neumann outward-normal gradient
-        into the half-cell ghost offset ``sign · gradient · dz``.
+        ``dz`` is required to translate a Neumann coordinate gradient
+        ``∂C/∂z`` into the half-cell ghost offset ``sign · gradient · dz``.
         """
         out = _apply_vertical_face(
             field,
@@ -112,9 +113,14 @@ def _apply_vertical_face(
 ) -> Float[Array, "Nz Ny Nx"]:
     """Update one vertical ghost slice using the requested BC flavour.
 
-    Conventions match :class:`finitevolx.Neumann1D`: the ``value`` for
-    a Neumann BC is the *outward-normal* gradient, i.e. along ``-z`` at
-    the bottom face and along ``+z`` at the top face.
+    Neumann convention: ``value`` is the coordinate gradient ``∂C/∂z``
+    along ``+z``, applied identically on both faces — the ghost cell is
+    set so the finite-difference ``∂C/∂z`` across the face equals
+    ``value``. The ``outward_sign`` factor (``-1`` at the bottom, ``+1``
+    at the top) is what makes the *same* ``value`` mean ``∂C/∂z`` at
+    both faces despite the ghost sitting below the interior at the
+    bottom and above it at the top; this matches the ghost sign of
+    :class:`finitevolx.Neumann1D`.
     """
     if face == "bottom":
         interior_slice = field[1, :, :]
@@ -130,8 +136,9 @@ def _apply_vertical_face(
     if kind == "dirichlet":
         ghost = 2.0 * value - interior_slice
     elif kind == "neumann":
-        # Ghost value so that the finite-difference outward-normal gradient
-        # across the wall equals ``value``. Matches finitevolX.Neumann1D.
+        # Ghost value so that the finite-difference coordinate gradient
+        # ``∂C/∂z`` (along +z) across the face equals ``value``. The
+        # outward_sign flip keeps that meaning identical on both faces.
         ghost = interior_slice + outward_sign * value * dz
     elif kind == "outflow":
         ghost = interior_slice

--- a/src/plumax/les_fvm/fourdvar.py
+++ b/src/plumax/les_fvm/fourdvar.py
@@ -137,6 +137,11 @@ class EulerianForward4DVar:
             "max_steps": 100_000,
             **self.solver_kwargs,
         }
+        # diffrax's StepTo controller prescribes its own step points and requires
+        # dt0=None; the default dt0=1.0 above would otherwise make the solve
+        # fail, so drop it whenever a StepTo controller is in effect.
+        if isinstance(kw["stepsize_controller"], diffrax.StepTo):
+            kw["dt0"] = None
         sol = diffrax.diffeqsolve(
             diffrax.ODETerm(rhs),
             kw["solver"],

--- a/src/plumax/les_fvm/fourdvar.py
+++ b/src/plumax/les_fvm/fourdvar.py
@@ -233,19 +233,26 @@ def build_forward(
 
     # Stability guard for the fixed-step 4D-Var solve. The default path is
     # Heun + ConstantStepSize + dt0=1 (see `concentration_history`); an
-    # over-large dt0 silently blows up *inside* the optimisation loop, where
+    # over-large step silently blows up *inside* the optimisation loop, where
     # it is hardest to diagnose. Check it once here on the static config
-    # (uniform wind + constant K), skipping only when the caller supplies an
-    # adaptive stepsize controller.
+    # (uniform wind + constant K). The largest step the solve will take is dt0
+    # for ConstantStepSize and the widest prescribed interval for StepTo — both
+    # fixed controllers; adaptive controllers (PIDController, …) are
+    # error-controlled, so the guard is skipped for them.
     import diffrax
 
-    from plumax.les_fvm.simulate import stable_step_bound
+    from plumax.les_fvm.simulate import _max_diffusivity, stable_step_bound
 
     _kw = dict(solver_kwargs or {})
     _controller = _kw.get("stepsize_controller", diffrax.ConstantStepSize())
+    _max_step: float | None = None
     if isinstance(_controller, diffrax.ConstantStepSize):
-        _dt0 = float(_kw.get("dt0", 1.0))
-        _k_h, _k_z = eddy.as_arrays()
+        _max_step = float(_kw.get("dt0", 1.0))
+    elif isinstance(_controller, diffrax.StepTo):
+        _ts = np.asarray(_controller.ts, dtype=float)
+        _max_step = float(np.max(np.diff(_ts))) if _ts.size >= 2 else 0.0
+    if _max_step is not None:
+        _k_h, _k_z = _max_diffusivity(eddy)
         _bound = stable_step_bound(
             dx=plume_grid.dx,
             dy=plume_grid.dy,
@@ -253,15 +260,15 @@ def build_forward(
             max_u=abs(float(uniform_wind[0])),
             max_v=abs(float(uniform_wind[1])),
             max_w=abs(float(uniform_wind[2])),
-            k_h=float(jnp.max(jnp.abs(jnp.asarray(_k_h)))),
-            k_z=float(jnp.max(jnp.abs(jnp.asarray(_k_z)))),
+            k_h=_k_h,
+            k_z=_k_z,
         )
-        if _dt0 > _bound:
+        if _max_step > _bound:
             raise ValueError(
-                f"build_forward: dt0={_dt0:g} s exceeds the stable step "
-                f"~{_bound:g} s for the fixed-step 4D-Var solve on this "
-                f"grid+wind+K. Reduce dt0 (solver_kwargs={{'dt0': ...}}), "
-                f"soften K, or pass an adaptive stepsize_controller."
+                f"build_forward: fixed step {_max_step:g} s exceeds the stable "
+                f"step ~{_bound:g} s for the fixed-step 4D-Var solve on this "
+                f"grid+wind+K. Reduce the step (solver_kwargs 'dt0' or StepTo "
+                f"'ts'), soften K, or pass an adaptive stepsize_controller."
             )
 
     horizontal_bc, vertical_bc = build_default_concentration_bc(

--- a/src/plumax/les_fvm/fourdvar.py
+++ b/src/plumax/les_fvm/fourdvar.py
@@ -404,6 +404,18 @@ def build_problem(
         raise ValueError(
             f"build_problem: `observations` must be (n_t={n_t}, n_obs), got {y.shape}."
         )
+    # Reject non-finite inputs: a NaN would flow through the cost / posterior as
+    # a finite-`source` solve with a NaN objective and covariance (the source-
+    # only divergence check in `solve_4dvar` cannot catch that).
+    for _name, _arr in (
+        ("prior_mean", sb),
+        ("prior_covariance", b),
+        ("observations", y),
+    ):
+        if not bool(jnp.all(jnp.isfinite(_arr))):
+            raise ValueError(
+                f"build_problem: `{_name}` must be finite (contains NaN/inf)."
+            )
     # Jitter keeps the Cholesky factor PD for smooth Matérn kernels.
     chol = jnp.linalg.cholesky(b + 1e-9 * jnp.eye(n_t))
 
@@ -425,8 +437,12 @@ def build_problem(
         )
     if r_in.ndim == 1 and r_in.shape[0] == n_t:
         r_in = r_in[:, None]
-    if np.any(r_in <= 0.0):
-        raise ValueError("build_problem: `obs_variance` entries must be > 0.")
+    if not np.all(np.isfinite(r_in)) or np.any(r_in <= 0.0):
+        # NaN passes ``<= 0`` (every comparison is False), so check finiteness
+        # explicitly — a NaN R would give a NaN cost and posterior.
+        raise ValueError(
+            "build_problem: `obs_variance` entries must be finite and > 0."
+        )
     try:
         r = jnp.broadcast_to(jnp.asarray(r_in), y.shape)
     except (ValueError, TypeError) as exc:

--- a/src/plumax/les_fvm/fourdvar.py
+++ b/src/plumax/les_fvm/fourdvar.py
@@ -276,7 +276,7 @@ def build_forward(
                 f"build_forward: fixed step {_max_step:g} s exceeds the stable "
                 f"step ~{_bound:g} s for the fixed-step 4D-Var solve on this "
                 f"grid+wind+K. Reduce the step (solver_kwargs 'dt0' or StepTo "
-                f"'ts'), soften K, or pass an adaptive/implicit solver."
+                f"'ts'), soften K, or pass an adaptive stepsize_controller."
             )
 
     horizontal_bc, vertical_bc = build_default_concentration_bc(
@@ -532,15 +532,24 @@ def solve_4dvar(
     converged = bool(sol.result == optx.RESULTS.successful)
     chi_star = sol.value
     source = problem.source_from_whitened(chi_star)
-    if not bool(jnp.all(jnp.isfinite(source))):
+    finite = bool(jnp.all(jnp.isfinite(source)))
+    if not finite:
         warnings.warn(
             f"solve_4dvar: the optimiser returned a non-finite source "
-            f"(result={sol.result}); the solve diverged. Check the prior "
-            f"conditioning, `obs_variance`, and `initial_source`.",
+            f"(result={sol.result}); the solve diverged. The posterior is "
+            f"skipped (it would be NaN). Check the prior conditioning, "
+            f"`obs_variance`, and `initial_source`.",
             RuntimeWarning,
             stacklevel=2,
         )
-    posterior = posterior_covariance(problem, chi_star) if compute_posterior else None
+    # Skip the posterior on a non-finite MAP: evaluating the Gauss-Newton
+    # Jacobian + inverse at a NaN control would raise or attach a NaN covariance
+    # — the exact downstream poisoning the finiteness check exists to prevent.
+    posterior = (
+        posterior_covariance(problem, chi_star)
+        if compute_posterior and finite
+        else None
+    )
     return FourDVarResult(
         source=source,
         whitened=chi_star,

--- a/src/plumax/les_fvm/fourdvar.py
+++ b/src/plumax/les_fvm/fourdvar.py
@@ -37,6 +37,7 @@ the Matérn-3/2 temporal prior from :mod:`plumax.lagrangian.inversion` supplies
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -229,6 +230,40 @@ def build_forward(
         w=uniform_wind[2],
     )
     eddy = make_eddy_diffusivity(eddy_diffusivity)
+
+    # Stability guard for the fixed-step 4D-Var solve. The default path is
+    # Heun + ConstantStepSize + dt0=1 (see `concentration_history`); an
+    # over-large dt0 silently blows up *inside* the optimisation loop, where
+    # it is hardest to diagnose. Check it once here on the static config
+    # (uniform wind + constant K), skipping only when the caller supplies an
+    # adaptive stepsize controller.
+    import diffrax
+
+    from plumax.les_fvm.simulate import stable_step_bound
+
+    _kw = dict(solver_kwargs or {})
+    _controller = _kw.get("stepsize_controller", diffrax.ConstantStepSize())
+    if isinstance(_controller, diffrax.ConstantStepSize):
+        _dt0 = float(_kw.get("dt0", 1.0))
+        _k_h, _k_z = eddy.as_arrays()
+        _bound = stable_step_bound(
+            dx=plume_grid.dx,
+            dy=plume_grid.dy,
+            dz=plume_grid.dz,
+            max_u=abs(float(uniform_wind[0])),
+            max_v=abs(float(uniform_wind[1])),
+            max_w=abs(float(uniform_wind[2])),
+            k_h=float(jnp.max(jnp.abs(jnp.asarray(_k_h)))),
+            k_z=float(jnp.max(jnp.abs(jnp.asarray(_k_z)))),
+        )
+        if _dt0 > _bound:
+            raise ValueError(
+                f"build_forward: dt0={_dt0:g} s exceeds the stable step "
+                f"~{_bound:g} s for the fixed-step 4D-Var solve on this "
+                f"grid+wind+K. Reduce dt0 (solver_kwargs={{'dt0': ...}}), "
+                f"soften K, or pass an adaptive stepsize_controller."
+            )
+
     horizontal_bc, vertical_bc = build_default_concentration_bc(
         bc_x=("dirichlet", "outflow"), bc_y="periodic", bc_z=("neumann", "neumann")
     )
@@ -402,6 +437,12 @@ class FourDVarResult:
         whitened: Optimal whitened control ``χ*``, shape ``(n_t,)``.
         cost: Final cost value ``J(χ*)``.
         n_steps: Optimiser iterations consumed (``-1`` if not reported).
+        converged: optx's strict success flag (``sol.result == successful``).
+            L-BFGS on these stiff problems frequently exhausts ``max_steps``
+            while still returning a good, finite MAP, so ``converged is False``
+            with a finite ``source`` is common and not by itself alarming. The
+            genuine failure to watch for is a non-finite ``source`` (a diverged
+            solve), which :func:`solve_4dvar` warns about loudly.
         posterior: Optional :class:`PosteriorCovariance` around the MAP, attached
             when :func:`solve_4dvar` is called with ``compute_posterior=True``.
     """
@@ -410,6 +451,7 @@ class FourDVarResult:
     whitened: jax.Array
     cost: float
     n_steps: int
+    converged: bool = True
     posterior: PosteriorCovariance | None = None
 
 
@@ -463,13 +505,31 @@ def solve_4dvar(
         max_steps=max_steps,
         throw=False,
     )
+    # `throw=False` suppresses the failure exception, so surface the outcome
+    # instead of trusting `sol.value` blindly. `converged` is optx's strict
+    # success flag; L-BFGS on these stiff transport problems frequently
+    # exhausts `max_steps` while still returning a good, finite MAP, so a bare
+    # `converged is False` is common and not alarming on its own. The genuine
+    # hazard the caller must be warned about loudly is a *diverged* solve whose
+    # MAP is non-finite and would silently poison `posterior_covariance`.
+    converged = bool(sol.result == optx.RESULTS.successful)
     chi_star = sol.value
+    source = problem.source_from_whitened(chi_star)
+    if not bool(jnp.all(jnp.isfinite(source))):
+        warnings.warn(
+            f"solve_4dvar: the optimiser returned a non-finite source "
+            f"(result={sol.result}); the solve diverged. Check the prior "
+            f"conditioning, `obs_variance`, and `initial_source`.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
     posterior = posterior_covariance(problem, chi_star) if compute_posterior else None
     return FourDVarResult(
-        source=problem.source_from_whitened(chi_star),
+        source=source,
         whitened=chi_star,
         cost=float(problem.cost(chi_star)),
         n_steps=int(sol.stats.get("num_steps", -1)),
+        converged=converged,
         posterior=posterior,
     )
 

--- a/src/plumax/les_fvm/fourdvar.py
+++ b/src/plumax/les_fvm/fourdvar.py
@@ -231,19 +231,26 @@ def build_forward(
     )
     eddy = make_eddy_diffusivity(eddy_diffusivity)
 
-    # Stability guard for the fixed-step 4D-Var solve. The default path is
-    # Heun + ConstantStepSize + dt0=1 (see `concentration_history`); an
-    # over-large step silently blows up *inside* the optimisation loop, where
-    # it is hardest to diagnose. Check it once here on the static config
-    # (uniform wind + constant K). The largest step the solve will take is dt0
-    # for ConstantStepSize and the widest prescribed interval for StepTo — both
-    # fixed controllers; adaptive controllers (PIDController, …) are
-    # error-controlled, so the guard is skipped for them.
     import diffrax
 
     from plumax.les_fvm.simulate import _max_diffusivity, stable_step_bound
 
+    # Reject an invalid diffusivity regardless of the solver / controller: a
+    # negative (anti-diffusion) or non-finite K is unstable or guard-defeating
+    # even on the adaptive path, so validate it before any branch.
+    _k_h, _k_z = _max_diffusivity(eddy)
+
+    # Stability guard for the fixed-step 4D-Var solve. The default path is
+    # Heun + ConstantStepSize + dt0=1 (see `concentration_history`); an
+    # over-large step silently blows up *inside* the optimisation loop, where
+    # it is hardest to diagnose. The explicit CFL bound only applies to an
+    # explicit solver taking a fixed step, so the guard runs only when: (a) the
+    # controller is fixed — ConstantStepSize (largest step = dt0) or StepTo
+    # (largest step = widest prescribed interval) — and (b) the solver is
+    # explicit. Adaptive controllers are error-controlled and implicit solvers
+    # are stable at these steps, so both are skipped.
     _kw = dict(solver_kwargs or {})
+    _solver = _kw.get("solver", diffrax.Heun())
     _controller = _kw.get("stepsize_controller", diffrax.ConstantStepSize())
     _max_step: float | None = None
     if isinstance(_controller, diffrax.ConstantStepSize):
@@ -251,8 +258,9 @@ def build_forward(
     elif isinstance(_controller, diffrax.StepTo):
         _ts = np.asarray(_controller.ts, dtype=float)
         _max_step = float(np.max(np.diff(_ts))) if _ts.size >= 2 else 0.0
-    if _max_step is not None:
-        _k_h, _k_z = _max_diffusivity(eddy)
+    if _max_step is not None and not isinstance(
+        _solver, diffrax.AbstractImplicitSolver
+    ):
         _bound = stable_step_bound(
             dx=plume_grid.dx,
             dy=plume_grid.dy,
@@ -268,7 +276,7 @@ def build_forward(
                 f"build_forward: fixed step {_max_step:g} s exceeds the stable "
                 f"step ~{_bound:g} s for the fixed-step 4D-Var solve on this "
                 f"grid+wind+K. Reduce the step (solver_kwargs 'dt0' or StepTo "
-                f"'ts'), soften K, or pass an adaptive stepsize_controller."
+                f"'ts'), soften K, or pass an adaptive/implicit solver."
             )
 
     horizontal_bc, vertical_bc = build_default_concentration_bc(

--- a/src/plumax/les_fvm/fourdvar.py
+++ b/src/plumax/les_fvm/fourdvar.py
@@ -437,22 +437,24 @@ class FourDVarResult:
         whitened: Optimal whitened control ``χ*``, shape ``(n_t,)``.
         cost: Final cost value ``J(χ*)``.
         n_steps: Optimiser iterations consumed (``-1`` if not reported).
-        converged: optx's strict success flag (``sol.result == successful``).
-            L-BFGS on these stiff problems frequently exhausts ``max_steps``
-            while still returning a good, finite MAP, so ``converged is False``
-            with a finite ``source`` is common and not by itself alarming. The
-            genuine failure to watch for is a non-finite ``source`` (a diverged
-            solve), which :func:`solve_4dvar` warns about loudly.
         posterior: Optional :class:`PosteriorCovariance` around the MAP, attached
             when :func:`solve_4dvar` is called with ``compute_posterior=True``.
+        converged: optx's strict success flag (``sol.result == successful``).
+            Appended after ``posterior`` to preserve the positional constructor
+            contract. L-BFGS on these stiff problems frequently exhausts
+            ``max_steps`` while still returning a good, finite MAP, so
+            ``converged is False`` with a finite ``source`` is common and not by
+            itself alarming. The genuine failure to watch for is a non-finite
+            ``source`` (a diverged solve), which :func:`solve_4dvar` warns about
+            loudly.
     """
 
     source: jax.Array
     whitened: jax.Array
     cost: float
     n_steps: int
-    converged: bool = True
     posterior: PosteriorCovariance | None = None
+    converged: bool = True
 
 
 def solve_4dvar(

--- a/src/plumax/les_fvm/simulate.py
+++ b/src/plumax/les_fvm/simulate.py
@@ -183,6 +183,16 @@ def simulate_eulerian_dispersion(
         t_start=t_start,
         t_end=t_end,
     )
+    # Validate inputs independently of the solver: a negative / non-finite K is
+    # unstable (or guard-defeating) on the adaptive path too, and a malformed
+    # `max_wind_speed` would silently disable the fixed-step guard.
+    _max_diffusivity(eddy)
+    if max_wind_speed is not None and (
+        not np.isfinite(max_wind_speed) or max_wind_speed < 0.0
+    ):
+        raise ValueError(
+            f"max_wind_speed must be finite and non-negative (got {max_wind_speed!r})."
+        )
 
     horizontal_bc, vertical_bc = build_default_concentration_bc(
         bc_x=bc_x, bc_y=bc_y, bc_z=bc_z
@@ -411,6 +421,17 @@ def stable_step_bound(
     -------
     float
         The maximum stable ``dt0`` [s].
+
+    Notes
+    -----
+    This is a first-order (upwind / forward-Euler) sum-CFL estimate — a
+    conservative safety net that catches gross step-size errors (the
+    ``dt0``-orders-of-magnitude-too-large failure mode). It is **not** a
+    rigorous stability certificate for the higher-order or low-dissipation
+    reconstructions (e.g. the default ``weno5``, or ``naive``): those
+    semidiscrete operators have different stability regions, and an explicit
+    RK step can amplify their weakly-damped modes even below this bound. Keep
+    ``dt0`` comfortably under the reported value when using such schemes.
     """
     adv_rate = max_u / dx + max_v / dy + max_w / dz
     diff_rate = 2.0 * (k_h / dx**2 + k_h / dy**2 + k_z / dz**2)
@@ -435,14 +456,18 @@ def _max_wind_components(
 
 
 def _max_diffusivity(eddy: EddyDiffusivity) -> tuple[float, float]:
-    """Return ``(max K_h, max K_z)``, rejecting any negative diffusivity.
+    """Return ``(max K_h, max K_z)``, rejecting negative or non-finite ``K``.
 
     A negative ``K`` is anti-diffusion: its modes grow every explicit step, so
-    no positive ``dt0`` is stable. Taking ``|K|`` would let the guard approve a
-    step the real (negative-``K``) tendency then blows up on, so reject it.
+    no positive ``dt0`` is stable, and taking ``|K|`` would let the guard
+    approve a step the real (negative-``K``) tendency then blows up on. A
+    NaN/inf ``K`` makes every ``dt0 > bound`` comparison false, silently
+    disabling the guard while the tendency corrupts the solve. Reject both.
     """
     k_h_arr = jnp.asarray(eddy.as_arrays()[0])
     k_z_arr = jnp.asarray(eddy.as_arrays()[1])
+    if not bool(jnp.all(jnp.isfinite(k_h_arr)) & jnp.all(jnp.isfinite(k_z_arr))):
+        raise ValueError("eddy diffusivity must be finite; got a NaN/inf K.")
     k_min = min(float(jnp.min(k_h_arr)), float(jnp.min(k_z_arr)))
     if k_min < 0.0:
         raise ValueError(

--- a/src/plumax/les_fvm/simulate.py
+++ b/src/plumax/les_fvm/simulate.py
@@ -502,26 +502,28 @@ def _check_fixed_step_stability(
 ) -> None:
     """Raise if ``dt0`` exceeds the stable step for a fixed-step solver.
 
-    The wind's peak speed drives the advective CFL term. When
-    ``max_wind_speed`` is given it is taken as a conservative upper bound on
-    each component ``|u|, |v|, |w|`` and used directly — the robust choice for
-    an arbitrary callable wind whose peak the guard cannot otherwise know.
-    Otherwise the peak is estimated by sampling the field on a dense time grid
-    over ``[t_start, t_end]`` unioned with ``extra_sample_times`` (e.g. the
-    in-window ``WindSchedule`` knots, where a piecewise-linear schedule attains
-    its extrema). A callable that peaks between samples on a sub-grid timescale
-    and supplies no ``max_wind_speed`` can still be under-sampled.
+    The field is always sampled on a dense time grid over ``[t_start, t_end]``
+    unioned with ``extra_sample_times`` (e.g. the in-window ``WindSchedule``
+    knots, where a piecewise-linear schedule attains its extrema) — both to
+    estimate the peak speed that drives the advective CFL term and to reject a
+    non-finite wind. When ``max_wind_speed`` is given it overrides the sampled
+    maxima as a conservative per-component bound — the robust choice for a
+    callable whose peak sits between samples — while the sampling still runs so
+    the finiteness check is never bypassed.
     """
+    base = tuple(float(t) for t in np.linspace(t_start, t_end, 33))
+    # Union (dedup) the dense grid with the supplied extra times.
+    sample_times = tuple(
+        dict.fromkeys(base + tuple(float(t) for t in extra_sample_times))
+    )
+    # Always sample: this validates finiteness (raises on a NaN/inf wind) even
+    # when an override supplies the maxima.
+    sampled_u, sampled_v, sampled_w = _max_wind_components(wf, sample_times)
     if max_wind_speed is not None:
         peak = float(max_wind_speed)
         max_u = max_v = max_w = peak
     else:
-        base = tuple(float(t) for t in np.linspace(t_start, t_end, 33))
-        # Union (dedup) the dense grid with the supplied extra times.
-        sample_times = tuple(
-            dict.fromkeys(base + tuple(float(t) for t in extra_sample_times))
-        )
-        max_u, max_v, max_w = _max_wind_components(wf, sample_times)
+        max_u, max_v, max_w = sampled_u, sampled_v, sampled_w
     k_h, k_z = _max_diffusivity(eddy)
     bound = stable_step_bound(
         dx=plume_grid.dx,

--- a/src/plumax/les_fvm/simulate.py
+++ b/src/plumax/les_fvm/simulate.py
@@ -85,6 +85,7 @@ def simulate_eulerian_dispersion(
     rtol: float = 1e-3,
     atol: float = 1e-8,
     max_steps: int = 100_000,
+    max_wind_speed: float | None = None,
     # Initial condition
     initial_concentration: Float[Array, "Nz Ny Nx"] | None = None,
     seed: int = 0,
@@ -131,6 +132,12 @@ def simulate_eulerian_dispersion(
         Adaptive-step controller tolerances (ignored for fixed-step solvers).
     max_steps : int
         Upper bound on diffrax internal steps.
+    max_wind_speed : float, optional
+        Conservative upper bound on each wind component ``|u|, |v|, |w|``
+        [m/s], used only by the fixed-step stability guard. Supply it for a
+        callable wind whose peak the guard cannot otherwise sample reliably;
+        when ``None`` the peak is estimated from the field (dense time grid +
+        any ``WindSchedule`` knots in the window).
     initial_concentration : ndarray, optional
         Interior-shaped ``(nz, ny, nx)`` initial tracer field.  Defaults
         to zero.
@@ -197,6 +204,13 @@ def simulate_eulerian_dispersion(
     save_times = _build_save_times(
         t_start=t_start, t_end=t_end, save_interval=save_interval
     )
+    # In-window WindSchedule knots — a piecewise-linear schedule attains its
+    # speed extrema at knots, so feed them to the fixed-step stability guard so
+    # a fast knot between the dense samples is not missed.
+    knot_times: tuple[float, ...] = ()
+    if wind_schedule is not None:
+        knots = np.asarray(wind_schedule.times, dtype=float)
+        knot_times = tuple(float(t) for t in knots if t_start <= t <= t_end)
     solution = _solve(
         rhs=rhs,
         t_start=t_start,
@@ -208,6 +222,8 @@ def simulate_eulerian_dispersion(
         rtol=rtol,
         atol=atol,
         max_steps=max_steps,
+        extra_sample_times=knot_times,
+        max_wind_speed=max_wind_speed,
     )
     return _to_dataset(
         plume_grid=plume_grid,
@@ -418,6 +434,24 @@ def _max_wind_components(
     return max_u, max_v, max_w
 
 
+def _max_diffusivity(eddy: EddyDiffusivity) -> tuple[float, float]:
+    """Return ``(max K_h, max K_z)``, rejecting any negative diffusivity.
+
+    A negative ``K`` is anti-diffusion: its modes grow every explicit step, so
+    no positive ``dt0`` is stable. Taking ``|K|`` would let the guard approve a
+    step the real (negative-``K``) tendency then blows up on, so reject it.
+    """
+    k_h_arr = jnp.asarray(eddy.as_arrays()[0])
+    k_z_arr = jnp.asarray(eddy.as_arrays()[1])
+    k_min = min(float(jnp.min(k_h_arr)), float(jnp.min(k_z_arr)))
+    if k_min < 0.0:
+        raise ValueError(
+            "eddy diffusivity must be non-negative; a negative K is "
+            f"anti-diffusion and is unconditionally unstable (min K = {k_min:g})."
+        )
+    return float(jnp.max(k_h_arr)), float(jnp.max(k_z_arr))
+
+
 def _check_fixed_step_stability(
     *,
     plume_grid: PlumeGrid3D,
@@ -427,21 +461,32 @@ def _check_fixed_step_stability(
     t_start: float,
     t_end: float,
     solver_name: str,
+    extra_sample_times: tuple[float, ...] = (),
+    max_wind_speed: float | None = None,
 ) -> None:
     """Raise if ``dt0`` exceeds the stable step for a fixed-step solver.
 
-    The wind's peak speed is estimated by sampling the field on a dense time
-    grid over ``[t_start, t_end]`` — enough to catch a fast schedule knot or a
-    callable-wind peak away from the endpoints (a coarse 2–3 point sample would
-    miss those and under-estimate the advective rate). A callable that peaks
-    between grid points on a sub-sample timescale can still be under-sampled;
-    such winds should keep ``dt0`` comfortably below the reported bound.
+    The wind's peak speed drives the advective CFL term. When
+    ``max_wind_speed`` is given it is taken as a conservative upper bound on
+    each component ``|u|, |v|, |w|`` and used directly — the robust choice for
+    an arbitrary callable wind whose peak the guard cannot otherwise know.
+    Otherwise the peak is estimated by sampling the field on a dense time grid
+    over ``[t_start, t_end]`` unioned with ``extra_sample_times`` (e.g. the
+    in-window ``WindSchedule`` knots, where a piecewise-linear schedule attains
+    its extrema). A callable that peaks between samples on a sub-grid timescale
+    and supplies no ``max_wind_speed`` can still be under-sampled.
     """
-    sample_times = tuple(float(t) for t in np.linspace(t_start, t_end, 33))
-    max_u, max_v, max_w = _max_wind_components(wf, sample_times)
-    k_h_arr, k_z_arr = eddy.as_arrays()
-    k_h = float(jnp.max(jnp.abs(jnp.asarray(k_h_arr))))
-    k_z = float(jnp.max(jnp.abs(jnp.asarray(k_z_arr))))
+    if max_wind_speed is not None:
+        peak = float(max_wind_speed)
+        max_u = max_v = max_w = peak
+    else:
+        base = tuple(float(t) for t in np.linspace(t_start, t_end, 33))
+        # Union (dedup) the dense grid with the supplied extra times.
+        sample_times = tuple(
+            dict.fromkeys(base + tuple(float(t) for t in extra_sample_times))
+        )
+        max_u, max_v, max_w = _max_wind_components(wf, sample_times)
+    k_h, k_z = _max_diffusivity(eddy)
     bound = stable_step_bound(
         dx=plume_grid.dx,
         dy=plume_grid.dy,
@@ -514,6 +559,8 @@ def _solve(
     rtol: float,
     atol: float,
     max_steps: int,
+    extra_sample_times: tuple[float, ...] = (),
+    max_wind_speed: float | None = None,
 ):
     solver, adaptive = _pick_solver(solver_name)
     if adaptive:
@@ -530,6 +577,8 @@ def _solve(
             t_start=t_start,
             t_end=t_end,
             solver_name=solver_name,
+            extra_sample_times=extra_sample_times,
+            max_wind_speed=max_wind_speed,
         )
         stepsize_controller = diffrax.ConstantStepSize()
     return _solve_jit(

--- a/src/plumax/les_fvm/simulate.py
+++ b/src/plumax/les_fvm/simulate.py
@@ -445,10 +445,21 @@ def stable_step_bound(
 def _max_wind_components(
     wf: PrescribedWindField, sample_times: tuple[float, ...]
 ) -> tuple[float, float, float]:
-    """Component-wise max |u|, |v|, |w| over the interior at ``sample_times``."""
+    """Component-wise max |u|, |v|, |w| over the interior at ``sample_times``.
+
+    Raises on a non-finite sample: ``max(prev, nan)`` keeps ``prev`` (a NaN wind
+    would read as calm and let the guard approve a step the RHS then corrupts),
+    so reject it explicitly — the same treatment as the diffusivity check.
+    """
     max_u = max_v = max_w = 0.0
     for t in sample_times:
         u, v, w = wf(jnp.asarray(t, dtype=jnp.float32))
+        for name, comp in (("u", u), ("v", v), ("w", w)):
+            if not bool(jnp.all(jnp.isfinite(comp))):
+                raise ValueError(
+                    f"wind field has a non-finite {name} component at "
+                    f"t={float(t):g}; the CFL guard cannot bound a NaN/inf wind."
+                )
         max_u = max(max_u, float(jnp.max(jnp.abs(u))))
         max_v = max(max_v, float(jnp.max(jnp.abs(v))))
         max_w = max(max_w, float(jnp.max(jnp.abs(w))))

--- a/src/plumax/les_fvm/simulate.py
+++ b/src/plumax/les_fvm/simulate.py
@@ -366,16 +366,17 @@ def stable_step_bound(
 ) -> float:
     """Maximum stable step for an explicit fixed-step transport solve.
 
-    Returns the smaller of the advective CFL bound and the explicit
-    diffusion bound, scaled by ``cfl_safety``::
+    Advection and diffusion are advanced in the *same* explicit step, so
+    their tendencies add and the conservative forward-Euler / Heun limit is
+    set by the summed rate::
 
-        dt_adv  = 1 / (|u|/dx + |v|/dy + |w|/dz)
-        dt_diff = 1 / (2·(K_h/dx² + K_h/dy² + K_z/dz²))
-        bound   = cfl_safety · min(dt_adv, dt_diff)
+        adv_rate  = |u|/dx + |v|/dy + |w|/dz
+        diff_rate = 2·(K_h/dx² + K_h/dy² + K_z/dz²)
+        bound     = cfl_safety / (adv_rate + diff_rate)
 
-    A term whose rate is zero (motionless component / no diffusion)
-    contributes no constraint (``inf``); the bound is ``inf`` only when the
-    field is both motionless and diffusion-free.
+    Using ``min(1/adv_rate, 1/diff_rate)`` instead would permit up to a 2×
+    step when the two rates are comparable. The bound is ``inf`` only when
+    the field is both motionless and diffusion-free.
 
     Parameters
     ----------
@@ -397,9 +398,11 @@ def stable_step_bound(
     """
     adv_rate = max_u / dx + max_v / dy + max_w / dz
     diff_rate = 2.0 * (k_h / dx**2 + k_h / dy**2 + k_z / dz**2)
-    dt_adv = float("inf") if adv_rate <= 0.0 else 1.0 / adv_rate
-    dt_diff = float("inf") if diff_rate <= 0.0 else 1.0 / diff_rate
-    return cfl_safety * min(dt_adv, dt_diff)
+    # Advection + diffusion act in the same explicit step, so the stable-step
+    # limit is set by the summed rate — 1/(adv_rate + diff_rate) — not by the
+    # looser min(1/adv_rate, 1/diff_rate).
+    total_rate = adv_rate + diff_rate
+    return float("inf") if total_rate <= 0.0 else cfl_safety / total_rate
 
 
 def _max_wind_components(
@@ -425,10 +428,17 @@ def _check_fixed_step_stability(
     t_end: float,
     solver_name: str,
 ) -> None:
-    """Raise if ``dt0`` exceeds the stable step for a fixed-step solver."""
-    max_u, max_v, max_w = _max_wind_components(
-        wf, (t_start, 0.5 * (t_start + t_end), t_end)
-    )
+    """Raise if ``dt0`` exceeds the stable step for a fixed-step solver.
+
+    The wind's peak speed is estimated by sampling the field on a dense time
+    grid over ``[t_start, t_end]`` — enough to catch a fast schedule knot or a
+    callable-wind peak away from the endpoints (a coarse 2–3 point sample would
+    miss those and under-estimate the advective rate). A callable that peaks
+    between grid points on a sub-sample timescale can still be under-sampled;
+    such winds should keep ``dt0`` comfortably below the reported bound.
+    """
+    sample_times = tuple(float(t) for t in np.linspace(t_start, t_end, 33))
+    max_u, max_v, max_w = _max_wind_components(wf, sample_times)
     k_h_arr, k_z_arr = eddy.as_arrays()
     k_h = float(jnp.max(jnp.abs(jnp.asarray(k_h_arr))))
     k_z = float(jnp.max(jnp.abs(jnp.asarray(k_z_arr))))

--- a/src/plumax/les_fvm/simulate.py
+++ b/src/plumax/les_fvm/simulate.py
@@ -352,6 +352,106 @@ def _build_initial_concentration(
     return jnp.pad(c0, ((1, 1), (1, 1), (1, 1)), mode="constant")
 
 
+def stable_step_bound(
+    *,
+    dx: float,
+    dy: float,
+    dz: float,
+    max_u: float,
+    max_v: float,
+    max_w: float,
+    k_h: float,
+    k_z: float,
+    cfl_safety: float = 1.0,
+) -> float:
+    """Maximum stable step for an explicit fixed-step transport solve.
+
+    Returns the smaller of the advective CFL bound and the explicit
+    diffusion bound, scaled by ``cfl_safety``::
+
+        dt_adv  = 1 / (|u|/dx + |v|/dy + |w|/dz)
+        dt_diff = 1 / (2·(K_h/dx² + K_h/dy² + K_z/dz²))
+        bound   = cfl_safety · min(dt_adv, dt_diff)
+
+    A term whose rate is zero (motionless component / no diffusion)
+    contributes no constraint (``inf``); the bound is ``inf`` only when the
+    field is both motionless and diffusion-free.
+
+    Parameters
+    ----------
+    dx, dy, dz : float
+        Grid spacing [m].
+    max_u, max_v, max_w : float
+        Component-wise maximum wind speed |u|, |v|, |w| over the run [m/s].
+    k_h, k_z : float
+        Maximum horizontal / vertical eddy diffusivity [m²/s].
+    cfl_safety : float, default 1.0
+        Multiplier on the raw stability bound.  ``1.0`` is the forward-Euler
+        sum-CFL / FTCS-diffusion limit; the RK schemes used here are at
+        least as stable, so this is a conservative guard.
+
+    Returns
+    -------
+    float
+        The maximum stable ``dt0`` [s].
+    """
+    adv_rate = max_u / dx + max_v / dy + max_w / dz
+    diff_rate = 2.0 * (k_h / dx**2 + k_h / dy**2 + k_z / dz**2)
+    dt_adv = float("inf") if adv_rate <= 0.0 else 1.0 / adv_rate
+    dt_diff = float("inf") if diff_rate <= 0.0 else 1.0 / diff_rate
+    return cfl_safety * min(dt_adv, dt_diff)
+
+
+def _max_wind_components(
+    wf: PrescribedWindField, sample_times: tuple[float, ...]
+) -> tuple[float, float, float]:
+    """Component-wise max |u|, |v|, |w| over the interior at ``sample_times``."""
+    max_u = max_v = max_w = 0.0
+    for t in sample_times:
+        u, v, w = wf(jnp.asarray(t, dtype=jnp.float32))
+        max_u = max(max_u, float(jnp.max(jnp.abs(u))))
+        max_v = max(max_v, float(jnp.max(jnp.abs(v))))
+        max_w = max(max_w, float(jnp.max(jnp.abs(w))))
+    return max_u, max_v, max_w
+
+
+def _check_fixed_step_stability(
+    *,
+    plume_grid: PlumeGrid3D,
+    wf: PrescribedWindField,
+    eddy: EddyDiffusivity,
+    dt0: float,
+    t_start: float,
+    t_end: float,
+    solver_name: str,
+) -> None:
+    """Raise if ``dt0`` exceeds the stable step for a fixed-step solver."""
+    max_u, max_v, max_w = _max_wind_components(
+        wf, (t_start, 0.5 * (t_start + t_end), t_end)
+    )
+    k_h_arr, k_z_arr = eddy.as_arrays()
+    k_h = float(jnp.max(jnp.abs(jnp.asarray(k_h_arr))))
+    k_z = float(jnp.max(jnp.abs(jnp.asarray(k_z_arr))))
+    bound = stable_step_bound(
+        dx=plume_grid.dx,
+        dy=plume_grid.dy,
+        dz=plume_grid.dz,
+        max_u=max_u,
+        max_v=max_v,
+        max_w=max_w,
+        k_h=k_h,
+        k_z=k_z,
+    )
+    if dt0 > bound:
+        raise ValueError(
+            f"simulate_eulerian_dispersion: dt0={dt0:g} s exceeds the stable "
+            f"step ~{bound:g} s for fixed-step solver {solver_name!r} "
+            f"(advective CFL / explicit-diffusion limit on this grid+wind+K). "
+            f"Reduce dt0, soften K / coarsen the grid, or use an adaptive "
+            f"solver ('tsit5'/'dopri5')."
+        )
+
+
 def _pick_solver(name: SolverName):
     if name == "tsit5":
         return diffrax.Tsit5(), True
@@ -409,6 +509,18 @@ def _solve(
     if adaptive:
         stepsize_controller = diffrax.PIDController(rtol=rtol, atol=atol)
     else:
+        # Fixed-step solvers integrate at exactly dt0 with no error control,
+        # so guard the CFL / explicit-diffusion stability limit up front —
+        # otherwise an over-large dt0 silently blows up mid-solve.
+        _check_fixed_step_stability(
+            plume_grid=rhs.plume_grid,
+            wf=rhs.wind_field,
+            eddy=rhs.eddy_diffusivity,
+            dt0=dt0,
+            t_start=t_start,
+            t_end=t_end,
+            solver_name=solver_name,
+        )
         stepsize_controller = diffrax.ConstantStepSize()
     return _solve_jit(
         rhs=rhs,

--- a/src/plumax/les_fvm/wind.py
+++ b/src/plumax/les_fvm/wind.py
@@ -163,6 +163,19 @@ def wind_field_from_callable(
 ) -> PrescribedWindField:
     """General-purpose wind field from a user-supplied ``(t, X, Y, Z)`` function.
 
+    Each velocity component is sampled at its C-grid stagger point so the
+    field the advection operator consumes is correctly located:
+
+    - ``u`` at U-points — T-point coordinates shifted ``+dx/2`` in x,
+    - ``v`` at V-points — T-point coordinates shifted ``+dy/2`` in y,
+    - ``w`` at T-points (collocated, per the ``les_fvm`` convention).
+
+    ``fn`` is therefore evaluated three times — once per stagger — and
+    only the matching component is kept from each call.  A divergence-free
+    analytic wind sampled this way stays discretely divergence-free
+    (sampling all three at T-points would displace ``u``/``v`` by half a
+    cell and introduce spurious tracer sources).
+
     Parameters
     ----------
     plume_grid : PlumeGrid3D
@@ -176,8 +189,17 @@ def wind_field_from_callable(
     PrescribedWindField
     """
     X, Y, Z = coord_arrays_from_grid(plume_grid)
+    half_dx = 0.5 * plume_grid.dx
+    half_dy = 0.5 * plume_grid.dy
+    # Stagger the sampling coordinates: U-points sit half a cell east of
+    # the T-point in x, V-points half a cell north in y.
+    X_u = X + half_dx
+    Y_v = Y + half_dy
 
     def interior_fn(t):
-        return fn(t, X, Y, Z)
+        u = fn(t, X_u, Y, Z)[0]
+        v = fn(t, X, Y_v, Z)[1]
+        w = fn(t, X, Y, Z)[2]
+        return u, v, w
 
     return PrescribedWindField(plume_grid=plume_grid, interior_fn=interior_fn)

--- a/src/plumax/les_fvm/wind.py
+++ b/src/plumax/les_fvm/wind.py
@@ -21,6 +21,7 @@ operators.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Callable
 
 import equinox as eqx
@@ -99,7 +100,18 @@ def uniform_wind_field(
     Returns
     -------
     PrescribedWindField
+
+    Raises
+    ------
+    ValueError
+        If any of ``u``, ``v``, ``w`` is non-finite — a NaN/inf wind would make
+        the CFL bound NaN (disabling the fixed-step guard) and corrupt the solve.
     """
+    for name, comp in (("u", u), ("v", v), ("w", w)):
+        if not math.isfinite(float(comp)):
+            raise ValueError(
+                f"uniform_wind_field: {name} must be finite (got {comp!r})."
+            )
     nz, ny, nx = plume_grid.interior_shape
     u_arr = jnp.full((nz, ny, nx), u, dtype=plume_grid.x.dtype)
     v_arr = jnp.full((nz, ny, nx), v, dtype=plume_grid.x.dtype)

--- a/tests/les_fvm/test_fourdvar.py
+++ b/tests/les_fvm/test_fourdvar.py
@@ -228,6 +228,46 @@ def test_build_forward_rejects_negative_diffusivity():
         )
 
 
+def test_build_forward_rejects_negative_diffusivity_with_adaptive_controller():
+    # K validation is unconditional: a negative diffusivity is rejected even
+    # when an adaptive controller would otherwise skip the fixed-step guard.
+    import diffrax
+
+    save_times = jnp.linspace(0.0, 40.0, 5)
+    with pytest.raises(ValueError, match="non-negative"):
+        build_forward(
+            domain_x=(0.0, 400.0, 20),
+            domain_y=(-100.0, 100.0, 10),
+            domain_z=(0.0, 80.0, 4),
+            save_times=save_times,
+            source_location=(50.0, 0.0, 20.0),
+            uniform_wind=(4.0, 0.0, 0.0),
+            eddy_diffusivity=(-1.0, 1.0),
+            solver_kwargs={
+                "stepsize_controller": diffrax.PIDController(rtol=1e-3, atol=1e-6)
+            },
+        )
+
+
+def test_build_forward_skips_guard_for_implicit_solver():
+    # An implicit solver is stable at large fixed steps, so the explicit CFL
+    # guard must not reject it — build_forward should succeed even at a huge dt0.
+    import diffrax
+
+    save_times = jnp.linspace(0.0, 40.0, 5)
+    fwd = build_forward(
+        domain_x=(0.0, 400.0, 20),
+        domain_y=(-100.0, 100.0, 10),
+        domain_z=(0.0, 80.0, 4),
+        save_times=save_times,
+        source_location=(50.0, 0.0, 20.0),
+        uniform_wind=(4.0, 0.0, 0.0),
+        eddy_diffusivity=2.0,
+        solver_kwargs={"solver": diffrax.Kvaerno5(), "dt0": 1000.0},
+    )
+    assert isinstance(fwd, EulerianForward4DVar)
+
+
 # ── validation ───────────────────────────────────────────────────────────────
 
 

--- a/tests/les_fvm/test_fourdvar.py
+++ b/tests/les_fvm/test_fourdvar.py
@@ -420,6 +420,37 @@ def test_build_problem_rejects_ambiguous_square_variance_vector():
         np.testing.assert_allclose(np.asarray(prob.obs_variance[t]), float(t + 1))
 
 
+def test_build_problem_rejects_nonfinite_obs_variance():
+    # NaN passes the `<= 0` check, so obs_variance finiteness must be enforced
+    # explicitly — otherwise the cost and posterior silently become NaN.
+    fwd = _forward()
+    y = fwd.predict(jnp.array([0.0, 1.0, 1.0, 0.5, 0.5]))
+    b = matern32_covariance(fwd.save_times, variance=1.0, length_scale=20.0)
+    with pytest.raises(ValueError, match="finite"):
+        build_problem(
+            forward=fwd,
+            observations=y,
+            prior_mean=jnp.zeros(5),
+            prior_covariance=b,
+            obs_variance=float("nan"),
+        )
+
+
+def test_build_problem_rejects_nonfinite_observations():
+    # A NaN observation would leave `source` finite but the cost/posterior NaN.
+    fwd = _forward()
+    y = fwd.predict(jnp.array([0.0, 1.0, 1.0, 0.5, 0.5])).at[0, 0].set(jnp.nan)
+    b = matern32_covariance(fwd.save_times, variance=1.0, length_scale=20.0)
+    with pytest.raises(ValueError, match="finite"):
+        build_problem(
+            forward=fwd,
+            observations=y,
+            prior_mean=jnp.zeros(5),
+            prior_covariance=b,
+            obs_variance=1.0,
+        )
+
+
 def test_build_problem_per_receptor_variance_vector():
     # A length-n_obs obs_variance stays per-receptor (broadcast across time).
     fwd = _forward()

--- a/tests/les_fvm/test_fourdvar.py
+++ b/tests/les_fvm/test_fourdvar.py
@@ -191,6 +191,43 @@ def test_solve_4dvar_flags_nonstrict_convergence_but_stays_finite():
     assert np.all(np.isfinite(np.asarray(res.source)))
 
 
+def test_build_forward_guards_stepto_controller():
+    # StepTo is a fixed (non-adaptive) controller, so the guard must inspect its
+    # widest prescribed interval rather than skip it as if it were adaptive.
+    import diffrax
+
+    save_times = jnp.linspace(0.0, 40.0, 5)
+    with pytest.raises(ValueError, match="stable step"):
+        build_forward(
+            domain_x=(0.0, 400.0, 20),
+            domain_y=(-100.0, 100.0, 10),
+            domain_z=(0.0, 80.0, 4),
+            save_times=save_times,
+            source_location=(50.0, 0.0, 20.0),
+            uniform_wind=(4.0, 0.0, 0.0),
+            eddy_diffusivity=2.0,
+            solver_kwargs={
+                "stepsize_controller": diffrax.StepTo(ts=jnp.asarray([0.0, 40.0]))
+            },
+        )
+
+
+def test_build_forward_rejects_negative_diffusivity():
+    # Negative (anti-diffusion) K is unconditionally unstable; the fixed-step
+    # 4D-Var guard must reject it rather than take |K|.
+    save_times = jnp.linspace(0.0, 40.0, 5)
+    with pytest.raises(ValueError, match="non-negative"):
+        build_forward(
+            domain_x=(0.0, 400.0, 20),
+            domain_y=(-100.0, 100.0, 10),
+            domain_z=(0.0, 80.0, 4),
+            save_times=save_times,
+            source_location=(50.0, 0.0, 20.0),
+            uniform_wind=(4.0, 0.0, 0.0),
+            eddy_diffusivity=(-1.0, 1.0),
+        )
+
+
 # ── validation ───────────────────────────────────────────────────────────────
 
 

--- a/tests/les_fvm/test_fourdvar.py
+++ b/tests/les_fvm/test_fourdvar.py
@@ -265,6 +265,29 @@ def test_build_forward_rejects_nonfinite_uniform_wind():
         )
 
 
+def test_build_forward_stepto_runs_with_stable_intervals():
+    # A stable StepTo config must actually run: dt0 is forced to None per
+    # diffrax's StepTo contract, so predict() succeeds instead of failing on the
+    # default dt0=1.0.
+    import diffrax
+
+    save_times = jnp.linspace(0.0, 40.0, 5)
+    fwd = build_forward(
+        domain_x=(0.0, 400.0, 20),
+        domain_y=(-100.0, 100.0, 10),
+        domain_z=(0.0, 80.0, 4),
+        save_times=save_times,
+        source_location=(50.0, 0.0, 20.0),
+        uniform_wind=(4.0, 0.0, 0.0),
+        eddy_diffusivity=2.0,
+        solver_kwargs={
+            "stepsize_controller": diffrax.StepTo(ts=jnp.arange(0.0, 41.0, 1.0))
+        },
+    )
+    y = fwd.predict(jnp.array([0.0, 1.0, 1.0, 0.5, 0.5]))
+    assert np.all(np.isfinite(np.asarray(y)))
+
+
 def test_build_forward_skips_guard_for_implicit_solver():
     # An implicit solver is stable at large fixed steps, so the explicit CFL
     # guard must not reject it — build_forward should succeed even at a huge dt0.

--- a/tests/les_fvm/test_fourdvar.py
+++ b/tests/les_fvm/test_fourdvar.py
@@ -7,6 +7,8 @@ the whitening transform, and end-to-end twin recovery — not large-scale physic
 
 from __future__ import annotations
 
+import warnings
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -172,6 +174,20 @@ def test_solve_from_explicit_initial_source():
     prob = _problem(fwd, q_true)
     res = solve_4dvar(prob, initial_source=jnp.full(5, 0.5), max_steps=40)
     assert res.source.shape == (5,)
+    assert np.all(np.isfinite(np.asarray(res.source)))
+
+
+def test_solve_4dvar_flags_nonstrict_convergence_but_stays_finite():
+    # Regression for #30: `throw=False` hides the optimiser outcome, so the
+    # result must expose it. A single step cannot meet optx's strict success
+    # criterion, so `converged` is False — yet the MAP is still finite (a good
+    # partial recovery, not a divergence), so no spurious warning is raised.
+    fwd = _forward()
+    prob = _problem(fwd, jnp.array([0.0, 1.0, 1.0, 0.5, 0.5]))
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        res = solve_4dvar(prob, max_steps=1)
+    assert res.converged is False
     assert np.all(np.isfinite(np.asarray(res.source)))
 
 

--- a/tests/les_fvm/test_fourdvar.py
+++ b/tests/les_fvm/test_fourdvar.py
@@ -249,6 +249,22 @@ def test_build_forward_rejects_negative_diffusivity_with_adaptive_controller():
         )
 
 
+def test_build_forward_rejects_nonfinite_uniform_wind():
+    # A NaN uniform-wind component makes the CFL bound NaN and bypasses the
+    # guard; reject it at wind-field construction (before any branch).
+    save_times = jnp.linspace(0.0, 40.0, 5)
+    with pytest.raises(ValueError, match="finite"):
+        build_forward(
+            domain_x=(0.0, 400.0, 20),
+            domain_y=(-100.0, 100.0, 10),
+            domain_z=(0.0, 80.0, 4),
+            save_times=save_times,
+            source_location=(50.0, 0.0, 20.0),
+            uniform_wind=(float("nan"), 0.0, 0.0),
+            eddy_diffusivity=2.0,
+        )
+
+
 def test_build_forward_skips_guard_for_implicit_solver():
     # An implicit solver is stable at large fixed steps, so the explicit CFL
     # guard must not reject it — build_forward should succeed even at a huge dt0.

--- a/tests/les_fvm/test_simulate.py
+++ b/tests/les_fvm/test_simulate.py
@@ -371,6 +371,34 @@ def test_stability_guard_honors_max_wind_speed_override():
         )
 
 
+def test_negative_diffusivity_rejected_even_for_adaptive_solver():
+    # Anti-diffusion is invalid regardless of solver; validation is unconditional
+    # (not gated behind the fixed-step guard), so an adaptive run also rejects it.
+    with pytest.raises(ValueError, match="non-negative"):
+        simulate_eulerian_dispersion(
+            **_common_kwargs(solver="tsit5", eddy_diffusivity=(-1.0, 1.0))
+        )
+
+
+def test_nonfinite_diffusivity_rejected():
+    # A NaN K makes every dt0 > bound comparison false, silently disabling the
+    # guard — so a non-finite diffusivity must be rejected outright.
+    with pytest.raises(ValueError, match="finite"):
+        simulate_eulerian_dispersion(
+            **_common_kwargs(
+                solver="heun", dt0=0.5, eddy_diffusivity=(float("nan"), 1.0)
+            )
+        )
+
+
+def test_invalid_max_wind_speed_rejected():
+    # A negative or non-finite override would zero/NaN the bound and disable the
+    # guard; it must be rejected at the entry point (before any solve).
+    for bad in (-1.0, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="max_wind_speed"):
+            simulate_eulerian_dispersion(**_common_kwargs(max_wind_speed=bad))
+
+
 def test_stability_guard_includes_schedule_knots():
     # A narrow high-speed knot at t=0.9 sits between the guard's dense samples
     # and is bracketed by calm knots at 0.8 and 1.0, so the uniform grid alone

--- a/tests/les_fvm/test_simulate.py
+++ b/tests/les_fvm/test_simulate.py
@@ -316,6 +316,14 @@ def test_stable_step_bound_formula():
         dx=10.0, dy=10.0, dz=10.0, max_u=0.0, max_v=0.0, max_w=0.0, k_h=1.0, k_z=1.0
     )
     np.testing.assert_allclose(diff, 1.0 / (2.0 * (0.01 + 0.01 + 0.01)))
+    # Combined: the advective and diffusive rates *add* (same explicit step),
+    # so the bound is 1/(adv_rate + diff_rate) = 1/(0.2 + 0.06), strictly
+    # tighter than the looser min() of the two individual bounds.
+    combined = stable_step_bound(
+        dx=10.0, dy=10.0, dz=10.0, max_u=2.0, max_v=0.0, max_w=0.0, k_h=1.0, k_z=1.0
+    )
+    np.testing.assert_allclose(combined, 1.0 / (0.2 + 0.06))
+    assert combined < min(5.0, 1.0 / 0.06)
     # Motionless and diffusion-free → no constraint.
     assert stable_step_bound(
         dx=1.0, dy=1.0, dz=1.0, max_u=0.0, max_v=0.0, max_w=0.0, k_h=0.0, k_z=0.0

--- a/tests/les_fvm/test_simulate.py
+++ b/tests/les_fvm/test_simulate.py
@@ -399,6 +399,35 @@ def test_invalid_max_wind_speed_rejected():
             simulate_eulerian_dispersion(**_common_kwargs(max_wind_speed=bad))
 
 
+def test_stability_guard_rejects_nonfinite_wind():
+    # A NaN wind component reads as calm through max(prev, nan), so the guard
+    # would approve a step the RHS then corrupts; the sampler must reject it.
+    from plumax.les_fvm.wind import wind_field_from_callable
+
+    g = make_grid((0.0, 400.0, 16), (0.0, 200.0, 8), (0.0, 80.0, 8))
+
+    def nan_wind(t, X, Y, Z):
+        del t, Y, Z
+        return jnp.full_like(X, jnp.nan), jnp.zeros_like(X), jnp.zeros_like(X)
+
+    wf = wind_field_from_callable(g, nan_wind)
+    with pytest.raises(ValueError, match="non-finite"):
+        simulate_eulerian_dispersion(
+            domain_x=(0.0, 400.0, 16),
+            domain_y=(0.0, 200.0, 8),
+            domain_z=(0.0, 80.0, 8),
+            t_start=0.0,
+            t_end=20.0,
+            save_interval=10.0,
+            emission_rate=0.1,
+            source_location=(50.0, 100.0, 20.0),
+            wind_field=wf,
+            eddy_diffusivity=(1.0, 1.0),
+            solver="heun",
+            dt0=0.5,
+        )
+
+
 def test_stability_guard_includes_schedule_knots():
     # A narrow high-speed knot at t=0.9 sits between the guard's dense samples
     # and is bracketed by calm knots at 0.8 and 1.0, so the uniform grid alone

--- a/tests/les_fvm/test_simulate.py
+++ b/tests/les_fvm/test_simulate.py
@@ -351,6 +351,53 @@ def test_adaptive_solver_skips_stability_guard():
     assert isinstance(ds, xr.Dataset)
 
 
+def test_stability_guard_rejects_negative_diffusivity():
+    # Anti-diffusion (negative K) is unconditionally unstable; taking |K| would
+    # let the guard approve a step the real tendency then blows up on, so the
+    # guard must reject a negative diffusivity outright.
+    with pytest.raises(ValueError, match="non-negative"):
+        simulate_eulerian_dispersion(
+            **_common_kwargs(solver="heun", dt0=0.1, eddy_diffusivity=(-1.0, 1.0))
+        )
+
+
+def test_stability_guard_honors_max_wind_speed_override():
+    # A caller-supplied conservative peak overrides the sampled estimate: a huge
+    # max_wind_speed tightens the advective CFL bound and rejects dt0 even
+    # though the actual (uniform 5 m/s) wind would be fine.
+    with pytest.raises(ValueError, match="stable step"):
+        simulate_eulerian_dispersion(
+            **_common_kwargs(solver="heun", dt0=0.5, max_wind_speed=1.0e6)
+        )
+
+
+def test_stability_guard_includes_schedule_knots():
+    # A narrow high-speed knot at t=0.9 sits between the guard's dense samples
+    # and is bracketed by calm knots at 0.8 and 1.0, so the uniform grid alone
+    # would miss it. Including the in-window schedule knots must catch the spike
+    # and reject the step.
+    schedule = WindSchedule.from_speed_direction(
+        times=jnp.asarray([0.0, 0.8, 0.9, 1.0, 20.0]),
+        wind_speed=jnp.asarray([0.01, 0.01, 1.0e4, 0.01, 0.01]),
+        wind_direction=jnp.full(5, 270.0),
+    )
+    with pytest.raises(ValueError, match="stable step"):
+        simulate_eulerian_dispersion(
+            domain_x=(0.0, 400.0, 16),
+            domain_y=(0.0, 200.0, 8),
+            domain_z=(0.0, 80.0, 8),
+            t_start=0.0,
+            t_end=20.0,
+            save_interval=10.0,
+            emission_rate=0.1,
+            source_location=(50.0, 100.0, 20.0),
+            wind_schedule=schedule,
+            eddy_diffusivity=(1.0, 1.0),
+            solver="heun",
+            dt0=0.5,
+        )
+
+
 def test_simulate_with_time_varying_wind_schedule():
     schedule = WindSchedule.from_speed_direction(
         times=jnp.linspace(0.0, 30.0, 7),

--- a/tests/les_fvm/test_simulate.py
+++ b/tests/les_fvm/test_simulate.py
@@ -302,6 +302,47 @@ def test_simulate_accepts_explicit_wind_field():
     assert float(ds["concentration"].max()) > 0.0
 
 
+def test_stable_step_bound_formula():
+    # Regression for #29: pin the advective-CFL / explicit-diffusion formula.
+    from plumax.les_fvm import stable_step_bound
+
+    # Pure advection: dt = 1 / (|u|/dx) = 1 / (2/10) = 5.
+    adv = stable_step_bound(
+        dx=10.0, dy=10.0, dz=10.0, max_u=2.0, max_v=0.0, max_w=0.0, k_h=0.0, k_z=0.0
+    )
+    np.testing.assert_allclose(adv, 5.0)
+    # Pure diffusion: dt = 1 / (2·(k_h/dx² + k_h/dy² + k_z/dz²)).
+    diff = stable_step_bound(
+        dx=10.0, dy=10.0, dz=10.0, max_u=0.0, max_v=0.0, max_w=0.0, k_h=1.0, k_z=1.0
+    )
+    np.testing.assert_allclose(diff, 1.0 / (2.0 * (0.01 + 0.01 + 0.01)))
+    # Motionless and diffusion-free → no constraint.
+    assert stable_step_bound(
+        dx=1.0, dy=1.0, dz=1.0, max_u=0.0, max_v=0.0, max_w=0.0, k_h=0.0, k_z=0.0
+    ) == float("inf")
+
+
+def test_fixed_step_solver_rejects_unstable_dt0():
+    # Regression for #29: a fixed-step solver with dt0 far above the CFL limit
+    # must raise before integration, not blow up mid-solve.
+    with pytest.raises(ValueError, match="stable step"):
+        simulate_eulerian_dispersion(**_common_kwargs(solver="heun", dt0=1000.0))
+
+
+def test_fixed_step_solver_runs_within_stability_bound():
+    # A bound-compliant dt0 on a fixed-step solver integrates normally.
+    ds = simulate_eulerian_dispersion(**_common_kwargs(solver="heun", dt0=0.5))
+    assert isinstance(ds, xr.Dataset)
+    assert float(ds["concentration"].max()) > 0.0
+
+
+def test_adaptive_solver_skips_stability_guard():
+    # The guard only applies to fixed-step solvers; an adaptive solver with a
+    # large dt0 (used only as the initial step) is not rejected.
+    ds = simulate_eulerian_dispersion(**_common_kwargs(solver="tsit5", dt0=1000.0))
+    assert isinstance(ds, xr.Dataset)
+
+
 def test_simulate_with_time_varying_wind_schedule():
     schedule = WindSchedule.from_speed_direction(
         times=jnp.linspace(0.0, 30.0, 7),

--- a/tests/les_fvm/test_simulate.py
+++ b/tests/les_fvm/test_simulate.py
@@ -428,6 +428,45 @@ def test_stability_guard_rejects_nonfinite_wind():
         )
 
 
+def test_max_wind_speed_override_still_rejects_nonfinite_wind():
+    # The override supplies the maxima but must not bypass finiteness: the field
+    # is still sampled, so a NaN callable wind is rejected even with an override.
+    from plumax.les_fvm.wind import wind_field_from_callable
+
+    g = make_grid((0.0, 400.0, 16), (0.0, 200.0, 8), (0.0, 80.0, 8))
+
+    def nan_wind(t, X, Y, Z):
+        del t, Y, Z
+        return jnp.full_like(X, jnp.nan), jnp.zeros_like(X), jnp.zeros_like(X)
+
+    wf = wind_field_from_callable(g, nan_wind)
+    with pytest.raises(ValueError, match="non-finite"):
+        simulate_eulerian_dispersion(
+            domain_x=(0.0, 400.0, 16),
+            domain_y=(0.0, 200.0, 8),
+            domain_z=(0.0, 80.0, 8),
+            t_start=0.0,
+            t_end=20.0,
+            save_interval=10.0,
+            emission_rate=0.1,
+            source_location=(50.0, 100.0, 20.0),
+            wind_field=wf,
+            eddy_diffusivity=(1.0, 1.0),
+            solver="heun",
+            dt0=0.5,
+            max_wind_speed=10.0,
+        )
+
+
+def test_nonfinite_uniform_wind_rejected():
+    # A NaN uniform-wind component would make the CFL bound NaN; reject it at
+    # wind-field construction, regardless of solver.
+    with pytest.raises(ValueError, match="finite"):
+        simulate_eulerian_dispersion(
+            **_common_kwargs(uniform_wind=(float("nan"), 0.0, 0.0))
+        )
+
+
 def test_stability_guard_includes_schedule_knots():
     # A narrow high-speed knot at t=0.9 sits between the guard's dense samples
     # and is bracketed by calm knots at 0.8 and 1.0, so the uniform grid alone

--- a/tests/les_fvm/test_wind.py
+++ b/tests/les_fvm/test_wind.py
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from plumax.gauss_puff.wind import WindSchedule
-from plumax.les_fvm.grid import make_grid
+from plumax.les_fvm.grid import coord_arrays_from_grid, make_grid
 from plumax.les_fvm.wind import (
     PrescribedWindField,
     uniform_wind_field,
@@ -67,6 +67,32 @@ def test_wind_field_from_callable_sees_coordinate_arrays():
         np.testing.assert_allclose(u_int[k].mean(), 0.1 * z_val, rtol=1e-4)
     np.testing.assert_allclose(np.asarray(v), 0.0)
     np.testing.assert_allclose(np.asarray(w), 0.0)
+
+
+def test_wind_field_from_callable_samples_components_at_stagger_points():
+    # Regression for #28: on a C-grid, u must be sampled at U-points
+    # (x + dx/2), v at V-points (y + dy/2), and w at T-points — not all
+    # three at the T-point, which would displace u/v by half a cell.
+    g = _build_grid()
+
+    def linear_flow(t, X, Y, Z):
+        del t, Z
+        # u varies in x, v varies in y, w varies in x (unshifted check).
+        return X, Y, X
+
+    wf = wind_field_from_callable(g, linear_flow)
+    u, v, w = wf(jnp.asarray(0.0))
+    u_int = np.asarray(u)[1:-1, 1:-1, 1:-1]
+    v_int = np.asarray(v)[1:-1, 1:-1, 1:-1]
+    w_int = np.asarray(w)[1:-1, 1:-1, 1:-1]
+
+    X, Y, _ = coord_arrays_from_grid(g)
+    X = np.asarray(X)
+    Y = np.asarray(Y)
+    # u half a cell east of the T-point, v half a cell north, w unshifted.
+    np.testing.assert_allclose(u_int, X + 0.5 * g.dx, rtol=1e-5)
+    np.testing.assert_allclose(v_int, Y + 0.5 * g.dy, rtol=1e-5)
+    np.testing.assert_allclose(w_int, X, rtol=1e-5)
 
 
 def test_prescribed_wind_field_returns_pytree():


### PR DESCRIPTION
Addresses epic #19 (les_fvm boundary-condition, staggering, and stability
correctness). This PR fixes the four tractable items; the two lateral-BC
issues are deferred upstream (see below).

## What's fixed

### #27 — vertical Neumann convention (docstring-only)
The vertical Neumann ghost sign matches `finitevolx.Neumann1D` but the
docstrings described it as an *outward-normal* gradient, which is the opposite
sign at the bottom face. Per the decision on #19, the **behavior is kept** (it
matches finitevolx) and the docs are corrected: `value` is the **+z coordinate
gradient ∂C/∂z**, applied identically on both faces. No behavior or test change
— the zero-gradient default and the existing PR-#16 regression test are
untouched.

### #28 — callable-wind C-grid staggering
`wind_field_from_callable` sampled all three components at T-points, but the
advection operator consumes `u`/`v` as **face** velocities. A spatially varying
callable wind was therefore displaced by half a cell (u by dx/2, v by dy/2),
so an analytically divergence-free wind was not discretely divergence-free.
It now samples `u` at U-points (`x + dx/2`), `v` at V-points (`y + dy/2`), and
`w` at T-points. Uniform / schedule winds are unaffected.

### #29 — CFL / diffusive stability guard for fixed-step solvers
Fixed-step solvers (`ssprk3`, `heun`, and the 4D-Var default `Heun + dt0=1`)
ran at exactly `dt0` with no error control, so an over-large step silently blew
up mid-solve (and inside the 4D-Var optimisation loop, where it's hardest to
diagnose). New public helper `stable_step_bound` returns the advective-CFL ∧
explicit-diffusion limit; `simulate_eulerian_dispersion` and
`fourdvar.build_forward` now raise a clear error before integrating when `dt0`
exceeds it. Adaptive solvers (`tsit5`/`dopri5`) skip the guard.

### #30 — 4D-Var optimiser convergence status
`solve_4dvar` used `optx.minimise(..., throw=False)` and returned `sol.value`
unconditionally, so a diverged solve (possibly NaN) was returned as if it
succeeded. `FourDVarResult` now carries a `converged` flag (optx's strict
success result), and `solve_4dvar` warns loudly when the returned MAP is
**non-finite** — the genuine hazard, since NaNs would otherwise propagate into
`posterior_covariance`.

> Note on #30: empirically, `optx.LBFGS` reports `max_steps_reached` for
> essentially every solve in the suite — including the twin experiment that
> recovers the truth, and even a run started at the exact optimum. So
> `converged` (strict success) is commonly `False` on a perfectly good, finite
> recovery, and warning on every non-success would be pure noise. The warning
> is therefore scoped to the non-finite (divergence) case the issue's Problem
> statement actually calls out. `converged` remains available as an honest
> passthrough of optx's flag, documented accordingly.

## Deferred: #25 / #26 (lateral BCs) → upstream

The lateral (x/y) BC failures are rooted in finitevolx's closed-domain operator
convention — `Advection3D` freezes the outer interior ring and (for `upwind1`)
never reads ghost cells; `Diffusion3D` hard-codes no-flux walls. Fixing these in
plumax would mean forking the finitevolx operators, so per the #19 decision they
are filed upstream as **jejjohnson/finitevolX#234** and left open here, blocked
on that fix. No advection/diffusion behavior is changed in this PR.

## Tests
- `test_wind_field_from_callable_samples_components_at_stagger_points` (#28)
- `test_stable_step_bound_formula`, `test_fixed_step_solver_rejects_unstable_dt0`,
  `test_fixed_step_solver_runs_within_stability_bound`,
  `test_adaptive_solver_skips_stability_guard` (#29)
- `test_solve_4dvar_flags_nonstrict_convergence_but_stays_finite` (#30)

`make test` (les_fvm suite), `ruff check .`, `ruff format --check .`, and
`ty check src/plumax` all pass.

Closes #27, #28, #29, #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEgZbnU2EmmhBrogbmxa9N

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEgZbnU2EmmhBrogbmxa9N)_