### PR TITLE
fix(les_fvm): open-wall BC consistency — cell-Dirichlet inflow + periodic seams (closes #60)

### DIFF
--- a/src/plumax/les_fvm/advection.py
+++ b/src/plumax/les_fvm/advection.py
@@ -33,6 +33,7 @@ def advection_tendency(
     w: Float[Array, "Nz Ny Nx"],
     plume_grid: PlumeGrid3D,
     method: str = "weno5",
+    periodic: tuple[bool, bool] = (False, False),
 ) -> Float[Array, "Nz Ny Nx"]:
     """Flux-form advective tendency ``-∇·(u C)`` at interior T-points.
 
@@ -51,6 +52,13 @@ def advection_tendency(
     method : str, default ``"weno5"``
         Horizontal reconstruction scheme.  Passed through to
         :class:`finitevolx.Advection3D`.
+    periodic : tuple[bool, bool], default ``(False, False)``
+        ``(x_periodic, y_periodic)``.  On a periodic axis the normal-velocity
+        ghost face is *wrapped* (rather than left edge-padded) so the two
+        representations of the periodic seam share one velocity and the
+        open-wall fluxes cancel — otherwise a spatially-varying normal wind
+        breaks exact mass conservation at the seam.  See
+        :func:`~plumax.les_fvm.boundary.periodic_axes`.
 
     Returns
     -------
@@ -68,6 +76,13 @@ def advection_tendency(
     :class:`~plumax.les_fvm.dynamics.EulerianDispersionRHS` runs every step.
     This is what makes horizontal transport honor ``bc_x`` / ``bc_y``.
     """
+    x_periodic, y_periodic = periodic
+    if x_periodic:
+        # Wrap the x-normal velocity seam: west wall face (u[..., 0]) and east
+        # wall face (u[..., -2]) are the same periodic seam and must match.
+        u = u.at[:, :, 0].set(u[:, :, -2]).at[:, :, -1].set(u[:, :, 1])
+    if y_periodic:
+        v = v.at[:, 0, :].set(v[:, -2, :]).at[:, -1, :].set(v[:, 1, :])
     horizontal_op = Advection3D(grid=plume_grid.grid)
     horizontal = horizontal_op(concentration, u, v, method=method, wall="open")
     vertical = vertical_advection_tendency(concentration, w, plume_grid.dz)

--- a/src/plumax/les_fvm/boundary.py
+++ b/src/plumax/les_fvm/boundary.py
@@ -34,6 +34,56 @@ from plumax.les_fvm.grid import PlumeGrid3D
 
 VerticalBCKind = Literal["dirichlet", "neumann", "outflow", "periodic"]
 
+HorizontalFace = Literal["south", "north", "west", "east"]
+
+
+class CellDirichlet1D(eqx.Module):
+    """Advective (cell-value) Dirichlet ghost for one horizontal face.
+
+    Writes ``ghost = value`` — the boundary concentration as an exterior
+    *cell* value — so a first-order upwind advective flux at an inflow wall
+    carries the prescribed ``value``.  This differs from
+    :class:`finitevolx.Dirichlet1D`, which writes the *face* reflection
+    ``2*value - interior`` (the correct convention for the centred diffusion
+    gradient, but wrong as the upwind cell value for advection — see
+    jejjohnson/finitevolX#235).
+
+    Parameters
+    ----------
+    face : {"south", "north", "west", "east"}
+        Domain face to update.
+    value : float
+        Boundary concentration written into the ghost cells.
+    """
+
+    face: HorizontalFace = eqx.field(static=True)
+    value: float
+
+    def __call__(
+        self, field: Float[Array, "Ny Nx"], dx: float, dy: float
+    ) -> Float[Array, "Ny Nx"]:
+        """Return ``field`` with one face's ghost set to ``value`` (cell value)."""
+        del dx, dy
+        if self.face == "south":
+            return field.at[0, :].set(self.value)
+        if self.face == "north":
+            return field.at[-1, :].set(self.value)
+        if self.face == "west":
+            return field.at[:, 0].set(self.value)
+        return field.at[:, -1].set(self.value)
+
+
+def _to_cell_dirichlet(atom):
+    """Swap a face-Dirichlet atom for its cell-value advective counterpart.
+
+    All other atoms (outflow / periodic / Neumann / ``None``) are returned
+    unchanged — only Dirichlet needs a different ghost convention for
+    advection versus diffusion.
+    """
+    if isinstance(atom, Dirichlet1D):
+        return CellDirichlet1D(face=atom.face, value=atom.value)
+    return atom
+
 
 class HorizontalBC(eqx.Module):
     """Apply a :class:`BoundaryConditionSet` to every z-slice of a 3-D field."""
@@ -52,6 +102,25 @@ class HorizontalBC(eqx.Module):
             return self.bc_set(slab, dx=dx, dy=dy)
 
         return eqx.filter_vmap(apply_slice)(field)
+
+    def advection_variant(self) -> HorizontalBC:
+        """Return a copy whose Dirichlet faces use a cell-value ghost.
+
+        Open-mode advection reads the ghost as an exterior *cell* value; a
+        face-Dirichlet ghost (``2*value - interior``) would make an inflow
+        carry the wrong state.  Outflow / periodic / Neumann faces are
+        unchanged, so this is a no-op unless a Dirichlet face is present.
+        """
+        bc_set = self.bc_set
+        return HorizontalBC(
+            bc_set=BoundaryConditionSet(
+                south=_to_cell_dirichlet(bc_set.south),
+                north=_to_cell_dirichlet(bc_set.north),
+                west=_to_cell_dirichlet(bc_set.west),
+                east=_to_cell_dirichlet(bc_set.east),
+                mask=bc_set.mask,
+            )
+        )
 
 
 class VerticalBC(eqx.Module):
@@ -76,6 +145,9 @@ class VerticalBC(eqx.Module):
     top_kind: VerticalBCKind = eqx.field(static=True)
     bottom_value: float = 0.0
     top_value: float = 0.0
+    # When True, a Dirichlet face writes ghost = value (a cell value) instead
+    # of the face reflection ``2*value - interior`` — the advection convention.
+    dirichlet_cell: bool = eqx.field(static=True, default=False)
 
     def __call__(
         self,
@@ -93,6 +165,7 @@ class VerticalBC(eqx.Module):
             kind=self.bottom_kind,
             value=self.bottom_value,
             dz=dz,
+            dirichlet_cell=self.dirichlet_cell,
         )
         out = _apply_vertical_face(
             out,
@@ -100,8 +173,24 @@ class VerticalBC(eqx.Module):
             kind=self.top_kind,
             value=self.top_value,
             dz=dz,
+            dirichlet_cell=self.dirichlet_cell,
         )
         return out
+
+    def advection_variant(self) -> VerticalBC:
+        """Return a copy whose Dirichlet faces use a cell-value ghost.
+
+        The vertical advection term also upwinds the ghost slice, so a
+        Dirichlet vertical inflow needs the same cell-value convention as the
+        horizontal faces.  A no-op unless a vertical Dirichlet face is set.
+        """
+        return VerticalBC(
+            bottom_kind=self.bottom_kind,
+            top_kind=self.top_kind,
+            bottom_value=self.bottom_value,
+            top_value=self.top_value,
+            dirichlet_cell=True,
+        )
 
 
 def _apply_vertical_face(
@@ -110,6 +199,7 @@ def _apply_vertical_face(
     kind: VerticalBCKind,
     value: float,
     dz: float,
+    dirichlet_cell: bool = False,
 ) -> Float[Array, "Nz Ny Nx"]:
     """Update one vertical ghost slice using the requested BC flavour.
 
@@ -134,7 +224,9 @@ def _apply_vertical_face(
         ghost_index = -1
 
     if kind == "dirichlet":
-        ghost = 2.0 * value - interior_slice
+        # Advection wants the boundary value as a cell value (ghost = value);
+        # diffusion wants the face reflection so the centred gradient sees it.
+        ghost = value if dirichlet_cell else (2.0 * value - interior_slice)
     elif kind == "neumann":
         # Ghost value so that the finite-difference coordinate gradient
         # ``∂C/∂z`` (along +z) across the face equals ``value``. The
@@ -160,6 +252,25 @@ def apply_boundary_conditions(
     out = horizontal_bc(field, dx=plume_grid.dx, dy=plume_grid.dy)
     out = vertical_bc(out, dz=plume_grid.dz)
     return out
+
+
+def periodic_axes(horizontal_bc: HorizontalBC) -> tuple[bool, bool]:
+    """Return ``(x_periodic, y_periodic)`` for a horizontal BC set.
+
+    A lateral axis is periodic when either of its paired faces carries a
+    :class:`finitevolx.Periodic1D` atom.  Used to decide whether the normal
+    wind / diffusivity halos must be wrapped (rather than edge-padded) so the
+    two representations of a periodic seam face share a coefficient and the
+    open-wall fluxes cancel.
+    """
+    bc_set = horizontal_bc.bc_set
+    x_periodic = isinstance(bc_set.west, Periodic1D) or isinstance(
+        bc_set.east, Periodic1D
+    )
+    y_periodic = isinstance(bc_set.south, Periodic1D) or isinstance(
+        bc_set.north, Periodic1D
+    )
+    return x_periodic, y_periodic
 
 
 def build_default_concentration_bc(

--- a/src/plumax/les_fvm/boundary.py
+++ b/src/plumax/les_fvm/boundary.py
@@ -257,20 +257,35 @@ def apply_boundary_conditions(
 def periodic_axes(horizontal_bc: HorizontalBC) -> tuple[bool, bool]:
     """Return ``(x_periodic, y_periodic)`` for a horizontal BC set.
 
-    A lateral axis is periodic when either of its paired faces carries a
-    :class:`finitevolx.Periodic1D` atom.  Used to decide whether the normal
-    wind / diffusivity halos must be wrapped (rather than edge-padded) so the
-    two representations of a periodic seam face share a coefficient and the
-    open-wall fluxes cancel.
+    Periodicity is an *axis* property — both paired faces must wrap together —
+    so this is used to decide whether the normal wind / diffusivity halos are
+    wrapped (rather than edge-padded), keeping the two representations of a
+    periodic seam face consistent and the open-wall fluxes cancelling.
+
+    Raises
+    ------
+    ValueError
+        If exactly one face of an axis is :class:`finitevolx.Periodic1D`.  A
+        half-periodic axis is ill-defined (the seam couples both faces), and
+        wrapping the axis' halos would corrupt the non-periodic face's
+        wall coefficient; require periodic on both faces or neither.
     """
     bc_set = horizontal_bc.bc_set
-    x_periodic = isinstance(bc_set.west, Periodic1D) or isinstance(
-        bc_set.east, Periodic1D
-    )
-    y_periodic = isinstance(bc_set.south, Periodic1D) or isinstance(
-        bc_set.north, Periodic1D
-    )
-    return x_periodic, y_periodic
+    west_p = isinstance(bc_set.west, Periodic1D)
+    east_p = isinstance(bc_set.east, Periodic1D)
+    south_p = isinstance(bc_set.south, Periodic1D)
+    north_p = isinstance(bc_set.north, Periodic1D)
+    if west_p != east_p:
+        raise ValueError(
+            "periodic BC on only one x-face (west/east); periodicity couples "
+            "both faces of an axis — set it on both faces or neither."
+        )
+    if south_p != north_p:
+        raise ValueError(
+            "periodic BC on only one y-face (south/north); periodicity couples "
+            "both faces of an axis — set it on both faces or neither."
+        )
+    return west_p, south_p
 
 
 def build_default_concentration_bc(

--- a/src/plumax/les_fvm/diffusion.py
+++ b/src/plumax/les_fvm/diffusion.py
@@ -82,6 +82,7 @@ def diffusion_tendency(
     concentration: Float[Array, "Nz Ny Nx"],
     eddy_diffusivity: EddyDiffusivity,
     plume_grid: PlumeGrid3D,
+    periodic: tuple[bool, bool] = (False, False),
 ) -> Float[Array, "Nz Ny Nx"]:
     """Full 3-D eddy diffusion tendency ``∇·(K ∇C)`` at interior T-points.
 
@@ -92,6 +93,12 @@ def diffusion_tendency(
     eddy_diffusivity : EddyDiffusivity
         ``(K_h, K_z)`` diagonal diffusivity.
     plume_grid : PlumeGrid3D
+    periodic : tuple[bool, bool], default ``(False, False)``
+        ``(x_periodic, y_periodic)``.  For a **field** ``K_h`` on a periodic
+        axis the coefficient ghost is *wrapped* (rather than left edge-padded
+        by :meth:`EddyDiffusivity.as_arrays`) so the paired periodic seam
+        faces share one diffusivity and their diffusive fluxes cancel.  A
+        scalar ``K_h`` is uniform and already conserves, so it is untouched.
 
     Returns
     -------
@@ -108,6 +115,14 @@ def diffusion_tendency(
     makes horizontal diffusion honor ``bc_x`` / ``bc_y``.
     """
     k_h, k_z = eddy_diffusivity.as_arrays()
+    x_periodic, y_periodic = periodic
+    if jnp.ndim(k_h) > 0:
+        # Field K_h: wrap the coefficient ghost on periodic axes so a periodic
+        # seam uses one shared face diffusivity (scalar K_h needs nothing).
+        if x_periodic:
+            k_h = k_h.at[:, :, 0].set(k_h[:, :, -2]).at[:, :, -1].set(k_h[:, :, 1])
+        if y_periodic:
+            k_h = k_h.at[:, 0, :].set(k_h[:, -2, :]).at[:, -1, :].set(k_h[:, 1, :])
     horizontal_op = Diffusion3D(grid=plume_grid.grid)
     horizontal = horizontal_op(concentration, k_h, wall="open")
     vertical = vertical_diffusion_tendency(concentration, k_z, plume_grid.dz)

--- a/src/plumax/les_fvm/dynamics.py
+++ b/src/plumax/les_fvm/dynamics.py
@@ -17,6 +17,7 @@ from plumax.les_fvm.boundary import (
     HorizontalBC,
     VerticalBC,
     apply_boundary_conditions,
+    periodic_axes,
 )
 from plumax.les_fvm.diffusion import EddyDiffusivity, diffusion_tendency
 from plumax.les_fvm.grid import PlumeGrid3D
@@ -60,22 +61,46 @@ class EulerianDispersionRHS(eqx.Module):
         """Return ``dC/dt`` at time ``t`` for tracer field ``concentration``."""
         del args
         # Enforce BCs before reading neighbours in the advection/diffusion
-        # stencils so ghost cells reflect the current physical BC state.
-        # The horizontal operators run in finitevolX ``wall="open"`` mode, so
-        # these ghost values drive the lateral wall fluxes (Dirichlet /
-        # outflow / periodic); the vertical operators read the top/bottom
-        # ghost slices directly.
-        c_bc = apply_boundary_conditions(
+        # stencils so ghost cells reflect the current physical BC state. The
+        # horizontal operators run in finitevolX ``wall="open"`` mode, so these
+        # ghost values drive the lateral wall fluxes; the vertical operators
+        # read the top/bottom ghost slices directly.
+        #
+        # Advection and diffusion need *different* Dirichlet ghosts: advection
+        # upwinds the ghost as an exterior cell value (ghost = value), while
+        # diffusion needs the face reflection (2*value - interior) so the
+        # centred gradient sees the boundary value. Outflow / periodic /
+        # Neumann ghosts are identical, so the two fills differ only at
+        # Dirichlet faces.
+        c_diff = apply_boundary_conditions(
             concentration,
             horizontal_bc=self.horizontal_bc,
             vertical_bc=self.vertical_bc,
             plume_grid=self.plume_grid,
         )
-        u, v, w = self.wind_field(t)
-        adv = advection_tendency(
-            c_bc, u, v, w, self.plume_grid, method=self.advection_scheme
+        c_adv = apply_boundary_conditions(
+            concentration,
+            horizontal_bc=self.horizontal_bc.advection_variant(),
+            vertical_bc=self.vertical_bc.advection_variant(),
+            plume_grid=self.plume_grid,
         )
-        diff = diffusion_tendency(c_bc, self.eddy_diffusivity, self.plume_grid)
+        u, v, w = self.wind_field(t)
+        # Wrap the normal wind / field-diffusivity halos on periodic axes so
+        # the paired seam faces stay conservative under a spatially-varying
+        # wind or K_h (see periodic_axes / the tendency `periodic=` argument).
+        periodic = periodic_axes(self.horizontal_bc)
+        adv = advection_tendency(
+            c_adv,
+            u,
+            v,
+            w,
+            self.plume_grid,
+            method=self.advection_scheme,
+            periodic=periodic,
+        )
+        diff = diffusion_tendency(
+            c_diff, self.eddy_diffusivity, self.plume_grid, periodic=periodic
+        )
         src = self.source(t)
         # Keep ghost-cell entries of the tendency zero; time integration writes
         # only to the interior and the BC pass above has already updated the

--- a/tests/les_fvm/test_open_wall_bc_consistency.py
+++ b/tests/les_fvm/test_open_wall_bc_consistency.py
@@ -203,6 +203,18 @@ def test_rhs_runs_and_is_interior_only():
     assert float(jnp.max(jnp.abs(out[:, :, 0]))) == 0.0
 
 
+def test_periodic_axes_rejects_half_periodic_axis():
+    import pytest
+
+    # west periodic, east Dirichlet — a half-periodic x-axis is ill-defined.
+    hbc, _ = build_default_concentration_bc(
+        bc_x=(("periodic", 0.0), ("dirichlet", 0.0)),
+        bc_y=("neumann", "neumann"),
+    )
+    with pytest.raises(ValueError, match=r"only one x-face"):
+        periodic_axes(hbc)
+
+
 def test_periodic_axes_detection():
     hbc, _ = build_default_concentration_bc(
         bc_x="periodic", bc_y=("dirichlet", "outflow")

--- a/tests/les_fvm/test_open_wall_bc_consistency.py
+++ b/tests/les_fvm/test_open_wall_bc_consistency.py
@@ -1,0 +1,214 @@
+"""Open-wall BC-consistency tests (issue #60).
+
+Open-mode advection/diffusion read the ghost ring, so every per-axis BC must
+be reflected consistently across the tracer *and* the coefficient/velocity
+halos:
+
+1. advection needs a **cell-value** Dirichlet ghost (``ghost = value``), while
+   diffusion needs the **face** reflection (``2*value - interior``);
+2. on a periodic axis the normal **wind** halo must be wrapped, not
+   edge-padded, or a spatially-varying wind breaks seam conservation;
+3. on a periodic axis a **field** ``K_h`` halo must be wrapped for the same
+   reason.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+
+from plumax.les_fvm.advection import advection_tendency
+from plumax.les_fvm.boundary import (
+    apply_boundary_conditions,
+    build_default_concentration_bc,
+    periodic_axes,
+)
+from plumax.les_fvm.diffusion import EddyDiffusivity, diffusion_tendency
+from plumax.les_fvm.dynamics import EulerianDispersionRHS
+from plumax.les_fvm.grid import make_grid
+from plumax.les_fvm.source import GaussianSource
+from plumax.les_fvm.wind import uniform_wind_field
+
+
+def _build_grid():
+    return make_grid(
+        domain_x=(0.0, 160.0, 16),
+        domain_y=(0.0, 160.0, 16),
+        domain_z=(0.0, 40.0, 4),
+    )
+
+
+def _wrap_xy(f):
+    f = f.at[:, :, 0].set(f[:, :, -2]).at[:, :, -1].set(f[:, :, 1])
+    f = f.at[:, 0, :].set(f[:, -2, :]).at[:, -1, :].set(f[:, 1, :])
+    return f
+
+
+def _edge_pad_interior(interior):
+    return jnp.asarray(
+        np.pad(np.asarray(interior), ((1, 1), (1, 1), (1, 1)), mode="edge")
+    )
+
+
+# ── 1. cell-Dirichlet advective ghost ───────────────────────────────────────
+def test_cell_dirichlet_advective_ghost_vs_face_reflection():
+    g = _build_grid()
+    hbc, vbc = build_default_concentration_bc(
+        bc_x=(("dirichlet", 3.0), "outflow"),
+        bc_y="periodic",
+        bc_z=(("dirichlet", 1.0), "neumann"),
+    )
+    c = jnp.full(g.shape, 5.0)
+    c_diff = apply_boundary_conditions(c, hbc, vbc, g)
+    c_adv = apply_boundary_conditions(
+        c, hbc.advection_variant(), vbc.advection_variant(), g
+    )
+    # West horizontal Dirichlet: diffusion 2*3-5=1 (face); advection 3 (cell).
+    np.testing.assert_allclose(float(c_diff[2, 2, 0]), 1.0)
+    np.testing.assert_allclose(float(c_adv[2, 2, 0]), 3.0)
+    # Bottom vertical Dirichlet: diffusion 2*1-5=-3 (face); advection 1 (cell).
+    np.testing.assert_allclose(float(c_diff[0, 3, 3]), 2.0 * 1.0 - 5.0)
+    np.testing.assert_allclose(float(c_adv[0, 3, 3]), 1.0)
+
+
+def test_advection_variant_is_noop_without_dirichlet():
+    g = _build_grid()
+    hbc, vbc = build_default_concentration_bc(
+        bc_x="periodic", bc_y=("outflow", "outflow"), bc_z=("neumann", "neumann")
+    )
+    rng = np.random.default_rng(0)
+    c = jnp.asarray(rng.normal(size=g.shape).astype(np.float32))
+    base = apply_boundary_conditions(c, hbc, vbc, g)
+    adv = apply_boundary_conditions(
+        c, hbc.advection_variant(), vbc.advection_variant(), g
+    )
+    np.testing.assert_array_equal(np.asarray(base), np.asarray(adv))
+
+
+def test_zero_dirichlet_inflow_injects_no_negative_tracer():
+    """A zero-Dirichlet inflow wall must not create negative concentration.
+
+    With the face reflection (ghost = -interior) an upwind inflow reads a
+    negative ghost and can drive the wall-adjacent cell negative; the
+    cell-value ghost (ghost = 0) keeps the monotone scheme non-negative.
+    """
+    g = _build_grid()
+    hbc, vbc = build_default_concentration_bc(
+        bc_x=(("dirichlet", 0.0), "outflow"),
+        bc_y=(("dirichlet", 0.0), ("dirichlet", 0.0)),
+        bc_z=("neumann", "neumann"),
+    )
+    hbc_a, vbc_a = hbc.advection_variant(), vbc.advection_variant()
+    # Tracer sitting on the west interior edge (i=1), +x inflow wind.
+    c = jnp.zeros(g.shape).at[2, 8, 1].set(1.0)
+    u = jnp.ones(g.shape)
+    v = jnp.zeros(g.shape)
+    w = jnp.zeros(g.shape)
+    for _ in range(30):
+        c = apply_boundary_conditions(c, hbc_a, vbc_a, g)
+        c = c + 0.1 * advection_tendency(c, u, v, w, g, method="upwind1")
+    assert float(jnp.min(c[1:-1, 1:-1, 1:-1])) >= -1e-6
+
+
+# ── 2. periodic wind seam ────────────────────────────────────────────────────
+def test_periodic_wind_seam_conserves_with_nonuniform_wind():
+    g = _build_grid()
+    rng = np.random.default_rng(1)
+    c = _wrap_xy(jnp.asarray(rng.normal(size=g.shape).astype(np.float64)))
+    # Spatially-varying normal winds; edge-padded halos break the seam match.
+    u = _edge_pad_interior(rng.uniform(0.5, 2.0, size=g.interior_shape))
+    v = _edge_pad_interior(rng.uniform(-1.5, 1.5, size=g.interior_shape))
+    w = jnp.zeros(g.shape)
+    wrapped = advection_tendency(c, u, v, w, g, method="upwind1", periodic=(True, True))
+    unwrapped = advection_tendency(
+        c, u, v, w, g, method="upwind1", periodic=(False, False)
+    )
+    # Fully periodic: matched seams => total interior tendency vanishes.
+    np.testing.assert_allclose(
+        float(jnp.sum(wrapped[1:-1, 1:-1, 1:-1])), 0.0, atol=1e-5
+    )
+    # Without wrapping the seam mismatch injects/removes mass.
+    assert abs(float(jnp.sum(unwrapped[1:-1, 1:-1, 1:-1]))) > 1e-3
+
+
+def test_periodic_wind_seam_wrap_only_flagged_axis():
+    """Wrapping is applied per-axis: x-periodic wraps u, leaves v alone."""
+    g = _build_grid()
+    rng = np.random.default_rng(2)
+    c = jnp.asarray(rng.normal(size=g.shape).astype(np.float64))
+    u = _edge_pad_interior(rng.uniform(0.5, 2.0, size=g.interior_shape))
+    v = jnp.zeros(g.shape)
+    w = jnp.zeros(g.shape)
+    only_x = advection_tendency(c, u, v, w, g, method="upwind1", periodic=(True, False))
+    none = advection_tendency(c, u, v, w, g, method="upwind1", periodic=(False, False))
+    # The x-wrap changes the west/east wall fluxes, so the result differs.
+    assert not np.allclose(np.asarray(only_x), np.asarray(none))
+
+
+# ── 3. periodic field-diffusivity seam ───────────────────────────────────────
+def test_periodic_field_kappa_seam_conserves():
+    g = _build_grid()
+    rng = np.random.default_rng(3)
+    c = _wrap_xy(jnp.asarray(rng.normal(size=g.shape).astype(np.float64)))
+    kh = jnp.asarray(rng.uniform(0.3, 1.0, size=g.interior_shape).astype(np.float64))
+    eddy = EddyDiffusivity(horizontal=kh, vertical=0.0)
+    wrapped = diffusion_tendency(c, eddy, g, periodic=(True, True))
+    unwrapped = diffusion_tendency(c, eddy, g, periodic=(False, False))
+    np.testing.assert_allclose(
+        float(jnp.sum(wrapped[1:-1, 1:-1, 1:-1])), 0.0, atol=1e-5
+    )
+    assert abs(float(jnp.sum(unwrapped[1:-1, 1:-1, 1:-1]))) > 1e-4
+
+
+def test_scalar_kappa_conserves_periodic_without_wrapping():
+    """A scalar K_h is uniform, so the seam already matches regardless."""
+    g = _build_grid()
+    rng = np.random.default_rng(4)
+    c = _wrap_xy(jnp.asarray(rng.normal(size=g.shape).astype(np.float64)))
+    eddy = EddyDiffusivity(horizontal=0.5, vertical=0.0)
+    t = diffusion_tendency(c, eddy, g, periodic=(True, True))
+    np.testing.assert_allclose(float(jnp.sum(t[1:-1, 1:-1, 1:-1])), 0.0, atol=1e-5)
+
+
+# ── RHS integration: the dual BC fill + periodicity are wired through ─────────
+def _zero_source(g):
+    return GaussianSource(
+        emission_fn=lambda t: jnp.asarray(0.0, dtype=jnp.float32),
+        density=jnp.zeros(g.interior_shape, dtype=jnp.float32),
+    )
+
+
+def test_rhs_runs_and_is_interior_only():
+    g = _build_grid()
+    hbc, vbc = build_default_concentration_bc(
+        bc_x=(("dirichlet", 0.0), "outflow"),
+        bc_y="periodic",
+        bc_z=("neumann", "neumann"),
+    )
+    rhs = EulerianDispersionRHS(
+        plume_grid=g,
+        wind_field=uniform_wind_field(g, u=2.0, v=0.0, w=0.0),
+        eddy_diffusivity=EddyDiffusivity(horizontal=0.5, vertical=0.1),
+        source=_zero_source(g),
+        horizontal_bc=hbc,
+        vertical_bc=vbc,
+        advection_scheme="upwind1",
+    )
+    c = jnp.zeros(g.shape).at[2, 8, 8].set(1.0)
+    out = rhs(jnp.asarray(0.0), c)
+    assert jnp.all(jnp.isfinite(out))
+    # Ghost ring of the tendency stays zero (interior-only integration).
+    assert float(jnp.max(jnp.abs(out[0, :, :]))) == 0.0
+    assert float(jnp.max(jnp.abs(out[:, 0, :]))) == 0.0
+    assert float(jnp.max(jnp.abs(out[:, :, 0]))) == 0.0
+
+
+def test_periodic_axes_detection():
+    hbc, _ = build_default_concentration_bc(
+        bc_x="periodic", bc_y=("dirichlet", "outflow")
+    )
+    assert periodic_axes(hbc) == (True, False)
+    hbc2, _ = build_default_concentration_bc(
+        bc_x=("outflow", "outflow"), bc_y="periodic"
+    )
+    assert periodic_axes(hbc2) == (False, True)


### PR DESCRIPTION
## Summary

Closes #60 — the three open-wall BC-consistency refinements deferred from #59. Open-mode advection/diffusion read the ghost ring, so a per-axis BC has to be reflected consistently in the tracer **and** the coefficient/velocity halos. All three were low-impact for the shipped default (scalar `K_h`, downwind plume) but are real correctness gaps for other configs.

## Changes

**1. Cell-Dirichlet ghost for advective inflow (was P1)**
`apply_boundary_conditions` fills a Dirichlet ghost with the *face* reflection `2·value − interior` (right for diffusion's centred gradient). Open-mode advection upwinds the ghost as an exterior *cell* value, so an inflow carried `2·value − interior` instead of `value` — a zero-Dirichlet inflow with near-wall tracer could inject negative concentration.
- New `CellDirichlet1D` atom (`ghost = value`) and `HorizontalBC.advection_variant()` / `VerticalBC.advection_variant()`.
- `EulerianDispersionRHS` now fills the ghost **twice** — cell-Dirichlet for advection, face-Dirichlet for diffusion — differing only at Dirichlet faces (outflow/periodic/Neumann are identical, so it's a no-op otherwise).

**2. Periodic wind seam (was P2)**
On a periodic axis the normal-velocity halo was edge-padded while the tracer wrapped, so a spatially-varying wind gave the two seam faces different velocities and broke conservation. `advection_tendency` gains `periodic=(x,y)` and wraps the normal-velocity halo on periodic axes.

**3. Periodic field-`K_h` seam (was P2)**
Same for a spatially-varying `EddyDiffusivity.horizontal`: `diffusion_tendency` gains `periodic=(x,y)` and wraps the `K_h` halo (a scalar `K_h` is uniform and already conserves). The RHS detects periodic axes with `boundary.periodic_axes` and threads the flag through both tendencies.

## Tests

`tests/les_fvm/test_open_wall_bc_consistency.py`:
- cell- vs face-Dirichlet ghost (horizontal **and** vertical faces);
- no negative injection at a zero-Dirichlet inflow over 30 steps;
- periodic wind-seam and field-`K_h`-seam conservation under **non-uniform** fields (total interior tendency → 0 wrapped, ≠ 0 unwrapped);
- scalar-`K_h` conserves unconditionally; per-axis wrapping; RHS integration (finite, interior-only).

Full `les_fvm` suite green: **124 passed**. `ruff check .` / `ruff format --check .` / `ty check src/plumax` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3NxHCEGifJAEEu8kjKNKb)_