### PR TITLE
fix(gauss_plume/puff): correct PG class-A σ_z, conserve puff mass, share wind solve (epic #20)

### DIFF
--- a/src/plumax/gauss_plume/inference.py
+++ b/src/plumax/gauss_plume/inference.py
@@ -187,14 +187,14 @@ def infer_emission_rate(
     infer_stability: bool = False,
     prior_mean: float = 0.1,
     prior_std: float = 0.05,
-    obs_noise_std: float = 5e-7,
-    background_prior_std: float = 5e-7,
     num_warmup: int = 500,
     num_samples: int = 1000,
     num_chains: int = 1,
     seed: int = 0,
     progress_bar: bool = False,
     print_summary: bool = False,
+    obs_noise_std: float = 5e-7,
+    background_prior_std: float = 5e-7,
 ) -> dict[str, NDArray]:
     """Infer the plume emission rate via NUTS.
 
@@ -219,12 +219,6 @@ def infer_emission_rate(
         If True, jointly sample a categorical stability-class latent.
     prior_mean, prior_std : float
         Prior parameters for the emission rate [kg/s].
-    obs_noise_std : float
-        Observation-noise σ for the Gaussian likelihood [kg/m³]. Set this to
-        the sensor noise so the posterior width reflects the instrument rather
-        than the hard-coded default.
-    background_prior_std : float
-        HalfNormal scale for the background-concentration prior [kg/m³].
     num_warmup, num_samples, num_chains : int
         NUTS sampler configuration.
     seed : int
@@ -233,6 +227,12 @@ def infer_emission_rate(
         If True, show the NumPyro progress bar. Default False.
     print_summary : bool
         If True, call ``mcmc.print_summary()`` after the run.
+    obs_noise_std : float
+        Observation-noise σ for the Gaussian likelihood [kg/m³]. Set this to
+        the sensor noise so the posterior width reflects the instrument rather
+        than the hard-coded default.
+    background_prior_std : float
+        HalfNormal scale for the background-concentration prior [kg/m³].
 
     Returns
     -------

--- a/src/plumax/gauss_plume/inference.py
+++ b/src/plumax/gauss_plume/inference.py
@@ -187,6 +187,8 @@ def infer_emission_rate(
     infer_stability: bool = False,
     prior_mean: float = 0.1,
     prior_std: float = 0.05,
+    obs_noise_std: float = 5e-7,
+    background_prior_std: float = 5e-7,
     num_warmup: int = 500,
     num_samples: int = 1000,
     num_chains: int = 1,
@@ -217,6 +219,12 @@ def infer_emission_rate(
         If True, jointly sample a categorical stability-class latent.
     prior_mean, prior_std : float
         Prior parameters for the emission rate [kg/s].
+    obs_noise_std : float
+        Observation-noise σ for the Gaussian likelihood [kg/m³]. Set this to
+        the sensor noise so the posterior width reflects the instrument rather
+        than the hard-coded default.
+    background_prior_std : float
+        HalfNormal scale for the background-concentration prior [kg/m³].
     num_warmup, num_samples, num_chains : int
         NUTS sampler configuration.
     seed : int
@@ -270,6 +278,15 @@ def infer_emission_rate(
         raise ValueError(
             f"infer_emission_rate: `prior_std` must be > 0 (got {prior_std!r})"
         )
+    if not (obs_noise_std > 0.0):
+        raise ValueError(
+            f"infer_emission_rate: `obs_noise_std` must be > 0 (got {obs_noise_std!r})"
+        )
+    if not (background_prior_std > 0.0):
+        raise ValueError(
+            "infer_emission_rate: `background_prior_std` must be > 0 "
+            f"(got {background_prior_std!r})"
+        )
 
     theta_rad = np.deg2rad(wind_direction)
     wind_u = float(-wind_speed * np.sin(theta_rad))
@@ -302,6 +319,8 @@ def infer_emission_rate(
         prior_emission_rate_mean=prior_mean,
         prior_emission_rate_std=prior_std,
         infer_stability=infer_stability,
+        obs_noise_std=obs_noise_std,
+        background_prior_std=background_prior_std,
     )
     if print_summary:
         mcmc.print_summary()

--- a/src/plumax/gauss_puff/dispersion.py
+++ b/src/plumax/gauss_puff/dispersion.py
@@ -49,9 +49,19 @@ STABILITY_CLASSES: tuple[str, ...] = ("A", "B", "C", "D", "E", "F")
 
 
 # Format: [a_y, b_y, c_y, a_z, b_z, c_z]
-# Log-quadratic PG coefficients (Beychok 2005, Table 3.2).
+# Log-quadratic PG coefficients (Beychok 2005, Table 3.2), i.e. the
+# McMullen (1975) fit ``σ = exp(I + J·ln x + K·(ln x)²)`` re-expressed with the
+# travel distance ``x`` in **metres** rather than km (the ``c`` column equals
+# McMullen's ``K``; ``a``/``b`` absorb the km→m shift ``ln x_km = ln x_m − ln
+# 1000``). Valid over the fitted PG range ~0.1–10 km; below ~0.1 km the
+# log-quadratic form is an extrapolation (class A's large ``c_z`` gives σ_z a
+# shallow spurious minimum near 20 m), and class-A σ_z grows very fast past a
+# few km — both inherent to the McMullen class-A fit.
 PG_DISPERSION_PARAMS: dict[str, jnp.ndarray] = {
-    "A": jnp.array([-1.104, 0.9878, -0.0076, 4.679, -1.172, 0.2770]),
+    # class-A b_z was a dropped-digit transcription (-1.172); the km→m
+    # conversion of McMullen's J=2.1097, K=0.2770 gives -1.7172. The old value
+    # inflated σ_z(1 km, A) to ~18 km (vs the correct ~418 m).
+    "A": jnp.array([-1.104, 0.9878, -0.0076, 4.679, -1.7172, 0.2770]),
     "B": jnp.array([-1.634, 1.0350, -0.0096, -1.999, 0.8752, 0.0136]),
     "C": jnp.array([-2.054, 1.0231, -0.0076, -2.341, 0.9477, -0.0020]),
     "D": jnp.array([-2.555, 1.0423, -0.0087, -3.186, 1.1737, -0.0316]),

--- a/src/plumax/gauss_puff/inference.py
+++ b/src/plumax/gauss_puff/inference.py
@@ -176,13 +176,13 @@ def gaussian_puff_model(
     schedule: WindSchedule | None = None,
     release_times: jnp.ndarray | None = None,
     release_interval: float | None = None,
-    puff_durations: jnp.ndarray | None = None,
     stability_class: str = "C",
     scheme: str = "pg",
     prior_emission_rate_mean: float = 0.1,
     prior_emission_rate_std: float = 0.05,
     background_prior_std: float = 5e-7,
     obs_noise_std: float = 5e-7,
+    puff_durations: jnp.ndarray | None = None,
 ) -> jnp.ndarray:
     """NumPyro model for the Gaussian puff forward with a constant Q prior.
 
@@ -296,7 +296,6 @@ def gaussian_puff_rw_model(
     schedule: WindSchedule,
     release_times: jnp.ndarray,
     release_interval: float,
-    puff_durations: jnp.ndarray | None = None,
     stability_class: str = "C",
     scheme: str = "pg",
     prior_emission_rate_mean: float = 0.1,
@@ -304,6 +303,7 @@ def gaussian_puff_rw_model(
     rw_step_std: float = 0.02,
     background_prior_std: float = 5e-7,
     obs_noise_std: float = 5e-7,
+    puff_durations: jnp.ndarray | None = None,
 ) -> jnp.ndarray:
     """Random-walk state-space model for a time-varying emission rate Q_i.
 

--- a/src/plumax/gauss_puff/inference.py
+++ b/src/plumax/gauss_puff/inference.py
@@ -32,12 +32,13 @@ from plumax.gauss_puff.dispersion import (
     get_dispersion_scheme,
 )
 from plumax.gauss_puff.puff import (
-    evolve_puffs,
+    PuffState,
     frequency_to_release_interval,
     make_release_times,
+    release_durations,
     simulate_puff_field,
 )
-from plumax.gauss_puff.wind import WindSchedule
+from plumax.gauss_puff.wind import WindSchedule, cumulative_wind_integrals
 
 
 def _forward_inputs_present(
@@ -112,16 +113,47 @@ def _predict_observations(
 
     Returns an array of shape ``(N_obs,)``: the k-th entry is the total
     puff field evaluated at ``(x[k], y[k], z[k])`` at time ``observation_times[k]``.
+
+    The wind integrals ``(I_u, I_v, S)`` at the release times are identical for
+    every observation, so — unlike a per-observation :func:`evolve_puffs` call —
+    the cumulative integrals are solved **once** over ``release_times ∪
+    observation_times`` and then gathered per observation. This turns ``N_obs``
+    adaptive ODE solves per likelihood evaluation into one, without changing the
+    result (same integrals, to solver tolerance).
     """
     x_obs, y_obs, z_obs = receptor_coords
+    src_x, src_y, src_z = source_location
 
-    def predict_one(x_k, y_k, z_k, t_k):
-        puff_state = evolve_puffs(
-            schedule,
-            release_times,
-            t_k,
-            source_location,
-            emission_per_puff,
+    # One diffrax solve over the union of release + observation times. SaveAt
+    # needs monotone times, so sort and unshuffle with the double-argsort trick.
+    all_times = jnp.concatenate([release_times, observation_times])
+    order = jnp.argsort(all_times)
+    i_u_s, i_v_s, s_s = cumulative_wind_integrals(schedule, all_times[order])
+    inv = jnp.argsort(order)
+    i_u, i_v, s_cum = i_u_s[inv], i_v_s[inv], s_s[inv]
+
+    n_rel = release_times.shape[0]
+    i_u_rel, i_v_rel, s_rel = i_u[:n_rel], i_v[:n_rel], s_cum[:n_rel]
+    i_u_obs, i_v_obs, s_obs = i_u[n_rel:], i_v[n_rel:], s_cum[n_rel:]
+
+    mass_arr = jnp.broadcast_to(jnp.asarray(emission_per_puff), release_times.shape)
+
+    def predict_one(x_k, y_k, z_k, t_k, iu_now, iv_now, s_now):
+        # Rebuild the puff ensemble at t_k from the shared release-time integrals
+        # (mirrors evolve_puffs, but with no per-observation ODE solve).
+        active = release_times <= t_k
+        x = src_x + jnp.where(active, iu_now - i_u_rel, 0.0)
+        y = src_y + jnp.where(active, iv_now - i_v_rel, 0.0)
+        z = jnp.full_like(release_times, src_z)
+        s = jnp.where(active, s_now - s_rel, 0.0)
+        mass = jnp.where(active, mass_arr, 0.0)
+        puff_state = PuffState(
+            release_times=release_times,
+            x=x,
+            y=y,
+            z=z,
+            travel_distance=s,
+            mass=mass,
         )
         single = simulate_puff_field(
             (jnp.atleast_1d(x_k), jnp.atleast_1d(y_k), jnp.atleast_1d(z_k)),
@@ -131,7 +163,9 @@ def _predict_observations(
         )
         return single[0]
 
-    return jax.vmap(predict_one)(x_obs, y_obs, z_obs, observation_times)
+    return jax.vmap(predict_one)(
+        x_obs, y_obs, z_obs, observation_times, i_u_obs, i_v_obs, s_obs
+    )
 
 
 def gaussian_puff_model(
@@ -142,6 +176,7 @@ def gaussian_puff_model(
     schedule: WindSchedule | None = None,
     release_times: jnp.ndarray | None = None,
     release_interval: float | None = None,
+    puff_durations: jnp.ndarray | None = None,
     stability_class: str = "C",
     scheme: str = "pg",
     prior_emission_rate_mean: float = 0.1,
@@ -174,8 +209,16 @@ def gaussian_puff_model(
     schedule : WindSchedule, optional
     release_times : jnp.ndarray, shape (N_puffs,), optional
     release_interval : float, optional
-        ``Δt_release`` [s]. Used to convert ``Q`` → per-puff mass
-        (``m = Q · Δt``). Required when a forward evaluation is needed.
+        ``Δt_release`` [s]. Required (as a presence flag) when a forward
+        evaluation is needed. Used for the per-puff mass ``m = Q · Δt`` only as
+        a fallback when ``puff_durations`` is not supplied.
+    puff_durations : jnp.ndarray, shape (N_puffs,), optional
+        Per-puff emission-interval durations [s] (from
+        :func:`plumax.gauss_puff.puff.release_durations`). When given, the
+        per-puff mass is ``m_i = Q · duration_i`` — so the trailing, possibly
+        partial interval carries only its actual duration, matching
+        ``simulate_puff`` and conserving emitted mass. Falls back to
+        ``Q · release_interval`` for every puff when omitted.
     stability_class : str
     scheme : str
         Dispersion scheme: ``'pg'`` or ``'briggs'``.
@@ -220,7 +263,10 @@ def gaussian_puff_model(
     )
 
     if forward_ready:
-        puff_mass = emission_rate * release_interval * jnp.ones_like(release_times)
+        if puff_durations is not None:
+            puff_mass = emission_rate * jnp.asarray(puff_durations)
+        else:
+            puff_mass = emission_rate * release_interval * jnp.ones_like(release_times)
         predicted = _predict_observations(
             puff_mass,
             release_times,
@@ -250,6 +296,7 @@ def gaussian_puff_rw_model(
     schedule: WindSchedule,
     release_times: jnp.ndarray,
     release_interval: float,
+    puff_durations: jnp.ndarray | None = None,
     stability_class: str = "C",
     scheme: str = "pg",
     prior_emission_rate_mean: float = 0.1,
@@ -302,7 +349,10 @@ def gaussian_puff_rw_model(
 
     background = numpyro.sample("background", dist.HalfNormal(background_prior_std))
 
-    puff_mass = emission_series * release_interval
+    if puff_durations is not None:
+        puff_mass = emission_series * jnp.asarray(puff_durations)
+    else:
+        puff_mass = emission_series * release_interval
     predicted = _predict_observations(
         puff_mass,
         release_times,
@@ -379,6 +429,24 @@ def _validate_inference_inputs(
         raise ValueError(
             f"{func_name}: `wind_direction` shape {wd.shape} must match "
             f"`wind_times` shape {wt.shape}"
+        )
+    # The cumulative wind integrals are solved from schedule.times[0], so any
+    # release or observation time earlier than the first wind knot lands before
+    # the ODE's t0 and raises an opaque diffrax error deep inside the trace.
+    # Catch it here with a clear message. (Extrapolation past wind_times[-1] is
+    # supported — see `cumulative_wind_integrals`.)
+    wind_start = float(wt[0])
+    if t_start < wind_start:
+        raise ValueError(
+            f"{func_name}: `t_start` ({t_start!r}) is before the wind schedule "
+            f"start `wind_times[0]` ({wind_start!r}); releases must lie within "
+            "the wind schedule."
+        )
+    obs_min = float(times.min())
+    if obs_min < wind_start:
+        raise ValueError(
+            f"{func_name}: earliest `observation_times` ({obs_min!r}) is before "
+            f"the wind schedule start `wind_times[0]` ({wind_start!r})."
         )
     if len(source_location) != 3:
         raise ValueError(
@@ -472,6 +540,9 @@ def infer_emission_rate(
     schedule = WindSchedule.from_speed_direction(wind_times, wind_speed, wind_direction)
     release_times = make_release_times(t_start, t_end, release_frequency)
     release_interval = frequency_to_release_interval(release_frequency)
+    # Per-puff durations conserve emitted mass: the trailing partial interval
+    # carries only its actual duration (matches simulate_puff).
+    puff_durations = release_durations(release_times, t_end)
 
     obs_jax = jnp.asarray(obs)
     coords_jax = tuple(jnp.asarray(c) for c in coords)
@@ -493,6 +564,7 @@ def infer_emission_rate(
         schedule=schedule,
         release_times=release_times,
         release_interval=release_interval,
+        puff_durations=puff_durations,
         stability_class=stability_class,
         scheme=scheme,
         prior_emission_rate_mean=prior_mean,
@@ -566,6 +638,7 @@ def infer_emission_timeseries(
     schedule = WindSchedule.from_speed_direction(wind_times, wind_speed, wind_direction)
     release_times = make_release_times(t_start, t_end, release_frequency)
     release_interval = frequency_to_release_interval(release_frequency)
+    puff_durations = release_durations(release_times, t_end)
 
     mcmc = MCMC(
         NUTS(gaussian_puff_rw_model),
@@ -583,6 +656,7 @@ def infer_emission_timeseries(
         schedule=schedule,
         release_times=release_times,
         release_interval=release_interval,
+        puff_durations=puff_durations,
         stability_class=stability_class,
         scheme=scheme,
         prior_emission_rate_mean=prior_mean,

--- a/tests/gauss_plume/test_inference.py
+++ b/tests/gauss_plume/test_inference.py
@@ -184,6 +184,99 @@ def test_infer_shape_mismatch_rejected():
         )
 
 
+# ── #33: observation-noise / background-prior scale passthrough ───────────────
+
+
+def test_obs_noise_std_passthrough():
+    # The runner's obs_noise_std / background_prior_std must reach the model's
+    # likelihood and background-prior sites, not stay pinned at the defaults.
+    # A seeded trace exposes each site's distribution scale directly.
+    from numpyro import handlers
+
+    seeded = handlers.seed(gaussian_plume_model, jax.random.PRNGKey(0))
+    trace = handlers.trace(seeded).get_trace(
+        observations=None,
+        receptor_coords=None,
+        source_location=None,
+        wind_u=None,
+        wind_v=None,
+        obs_noise_std=1.3e-6,
+        background_prior_std=7e-7,
+    )
+    np.testing.assert_allclose(np.asarray(trace["obs"]["fn"].scale), 1.3e-6, rtol=1e-6)
+    np.testing.assert_allclose(
+        np.asarray(trace["background"]["fn"].scale), 7e-7, rtol=1e-6
+    )
+
+
+def test_infer_emission_rate_rejects_nonpositive_noise_scales():
+    obs = np.array([1e-6, 2e-6])
+    coords = (np.array([500.0, 600.0]), np.zeros(2), np.ones(2))
+    with pytest.raises(ValueError, match=r"`obs_noise_std` must be > 0"):
+        infer_emission_rate(
+            obs,
+            coords,
+            (0, 0, 2),
+            wind_speed=5.0,
+            wind_direction=270.0,
+            obs_noise_std=0.0,
+            num_warmup=1,
+            num_samples=1,
+        )
+    with pytest.raises(ValueError, match=r"`background_prior_std` must be > 0"):
+        infer_emission_rate(
+            obs,
+            coords,
+            (0, 0, 2),
+            wind_speed=5.0,
+            wind_direction=270.0,
+            background_prior_std=-1e-7,
+            num_warmup=1,
+            num_samples=1,
+        )
+
+
+@pytest.mark.slow
+def test_obs_noise_std_widens_posterior():
+    # A larger observation-noise scale should yield a wider emission-rate
+    # posterior on the same data — confirming the knob is actually wired into
+    # the likelihood end-to-end through the runner.
+    stab = "D"
+    params = BRIGGS_DISPERSION_PARAMS[stab]
+    source = (0.0, 0.0, 2.0)
+    wind_u, wind_v = 5.0, 0.0
+    x_obs = jnp.linspace(200.0, 2000.0, 24)
+    y_obs = jnp.zeros_like(x_obs)
+    z_obs = jnp.ones_like(x_obs)
+    clean = plume_concentration(
+        x_obs, y_obs, z_obs, *source, wind_u, wind_v, 0.15, params
+    )
+    rng = np.random.default_rng(0)
+    noisy = np.asarray(clean) + rng.normal(0.0, 2e-8, size=clean.shape[0])
+    coords = (np.asarray(x_obs), np.asarray(y_obs), np.asarray(z_obs))
+
+    def run(noise):
+        return infer_emission_rate(
+            noisy,
+            coords,
+            source_location=source,
+            wind_speed=5.0,
+            wind_direction=270.0,
+            stability_class=stab,
+            prior_mean=0.1,
+            prior_std=0.08,
+            obs_noise_std=noise,
+            num_warmup=300,
+            num_samples=500,
+            num_chains=1,
+            seed=0,
+        )
+
+    std_tight = float(run(1e-8)["emission_rate"].std())
+    std_wide = float(run(1e-6)["emission_rate"].std())
+    assert std_wide > std_tight
+
+
 @pytest.mark.slow
 def test_infer_emission_rate_recovers_synthetic_Q():
     """NUTS should recover a synthetic emission rate from noisy transect data."""

--- a/tests/gauss_puff/test_dispersion.py
+++ b/tests/gauss_puff/test_dispersion.py
@@ -56,6 +56,36 @@ def test_pg_dispersion_monotone_increasing():
         assert jnp.all(jnp.diff(sz) > 0), f"σ_z not monotone for class {cls}"
 
 
+def test_pg_sigma_reference_values_at_1km():
+    # Regression for #31 + coefficient-integrity guard. At x = 1 km the McMullen
+    # (1975) fit reduces to σ = exp(I) (ln 1 km = 0), so the σ_y / σ_z the stored
+    # meter-coefficients produce at 1000 m must equal exp(McMullen intercept).
+    # This pins every class against its published PG curve and, in particular,
+    # catches the class-A σ_z transcription bug (old b_z=-1.172 → σ_z ≈ 18 km;
+    # correct b_z=-1.7172 → ≈ 418 m).
+    expected = {  # class: (σ_y at 1 km, σ_z at 1 km) [m] = (exp(I_y), exp(I_z))
+        "A": (212.1, 418.1),
+        "B": (157.2, 109.3),
+        "C": (104.7, 61.0),
+        "D": (68.7, 30.4),
+        "E": (50.5, 21.3),
+        "F": (34.2, 13.8),
+    }
+    for cls, (sy_ref, sz_ref) in expected.items():
+        _sx, sy, sz = calculate_pg_dispersion(
+            jnp.array(1000.0), PG_DISPERSION_PARAMS[cls]
+        )
+        np.testing.assert_allclose(float(sy), sy_ref, rtol=0.02, err_msg=f"σ_y {cls}")
+        np.testing.assert_allclose(float(sz), sz_ref, rtol=0.02, err_msg=f"σ_z {cls}")
+
+
+def test_pg_sigma_z_class_a_is_physical_not_kilometres():
+    # Direct anti-regression for the transcription bug: class-A σ_z at 1 km must
+    # be a few hundred metres, not the ~18 km the old coefficient produced.
+    _sx, _sy, sz = calculate_pg_dispersion(jnp.array(1000.0), PG_DISPERSION_PARAMS["A"])
+    assert 300.0 < float(sz) < 600.0
+
+
 def test_pg_dispersion_clamps_nonpositive_distance():
     # Distance clamp ensures ln(s) stays finite at s ≤ 0.
     params = PG_DISPERSION_PARAMS["D"]

--- a/tests/gauss_puff/test_inference.py
+++ b/tests/gauss_puff/test_inference.py
@@ -9,11 +9,18 @@ import pytest
 from numpyro.infer import Predictive
 
 from plumax.gauss_puff import make_release_times
+from plumax.gauss_puff.dispersion import get_dispersion_scheme
 from plumax.gauss_puff.inference import (
+    _predict_observations,
     gaussian_puff_model,
     gaussian_puff_rw_model,
     infer_emission_rate,
     infer_emission_timeseries,
+)
+from plumax.gauss_puff.puff import (
+    evolve_puffs,
+    release_durations,
+    simulate_puff_field,
 )
 from plumax.gauss_puff.wind import WindSchedule
 
@@ -237,6 +244,192 @@ def test_infer_emission_rate_rejects_bad_prior_mean():
             t_start=0.0,
             t_end=30.0,
             prior_mean=0.0,
+            num_warmup=1,
+            num_samples=1,
+        )
+
+
+# ── #35: shared wind-integral solve equals the per-observation path ───────────
+
+
+def test_predict_observations_matches_per_obs_evolve_puffs():
+    # The forward model solves the cumulative wind integrals ONCE over
+    # release ∪ observation times and gathers per observation. This must be
+    # numerically identical to the naive path that calls `evolve_puffs`
+    # (one ODE solve) per observation and evaluates the field there.
+    schedule = WindSchedule.from_speed_direction(
+        jnp.linspace(0.0, 60.0, 13),
+        jnp.linspace(4.0, 6.0, 13),  # non-constant speed exercises the integral
+        jnp.linspace(260.0, 280.0, 13),  # veering wind exercises I_u vs I_v
+    )
+    source_location = (0.0, 0.0, 2.0)
+    release_times = make_release_times(0.0, 60.0, 1.0)
+    durations = release_durations(release_times, 60.0)
+    emission_rate = 0.12
+    puff_mass = emission_rate * durations
+
+    x_obs = jnp.array([150.0, 250.0, 350.0, 200.0])
+    y_obs = jnp.array([0.0, 10.0, -5.0, 3.0])
+    z_obs = jnp.array([1.0, 1.0, 2.0, 0.0])
+    obs_times = jnp.array([30.0, 45.0, 55.0, 40.0])
+
+    params_dict, dispersion_fn = get_dispersion_scheme("pg")
+    dispersion_params = params_dict["C"]
+
+    shared = _predict_observations(
+        puff_mass,
+        release_times,
+        (x_obs, y_obs, z_obs),
+        obs_times,
+        source_location,
+        schedule,
+        dispersion_params,
+        dispersion_fn,
+    )
+
+    # Reference: independent evolve_puffs solve per observation.
+    ref = []
+    for k in range(x_obs.shape[0]):
+        state = evolve_puffs(
+            schedule,
+            release_times,
+            jnp.asarray(float(obs_times[k]), dtype=release_times.dtype),
+            source_location,
+            puff_mass,
+        )
+        field = simulate_puff_field(
+            (
+                jnp.atleast_1d(x_obs[k]),
+                jnp.atleast_1d(y_obs[k]),
+                jnp.atleast_1d(z_obs[k]),
+            ),
+            state,
+            dispersion_params,
+            dispersion_fn,
+        )
+        ref.append(float(field[0]))
+    ref_arr = np.asarray(ref)
+
+    # Both paths integrate the same wind schedule but over different SaveAt
+    # grids, so float32 diffrax picks slightly different adaptive steps: agree
+    # to solver tolerance, not bit-for-bit.
+    np.testing.assert_allclose(np.asarray(shared), ref_arr, rtol=3e-3, atol=1e-12)
+
+
+# ── #32: per-puff mass uses interval durations, conserving emitted mass ────────
+
+
+def test_partial_interval_mass_weights_trailing_puff():
+    # A window that is not an exact multiple of the release interval yields a
+    # trailing, partial puff. Weighting mass by release_durations (correct)
+    # must differ from the old flat `Q · Δt` weighting on exactly that puff,
+    # and only that puff.
+    release_times = make_release_times(0.0, 10.5, 1.0)  # 11 puffs, last partial
+    durations = release_durations(release_times, 10.5)
+    # Interior intervals are the full 1 s; the trailing one is the 0.5 s remainder.
+    np.testing.assert_allclose(np.asarray(durations[:-1]), 1.0, rtol=1e-5)
+    np.testing.assert_allclose(float(durations[-1]), 0.5, rtol=1e-5)
+
+    emission_rate = 0.1
+    duration_mass = emission_rate * durations
+    flat_mass = emission_rate * 1.0 * jnp.ones_like(release_times)
+    # The two mass vectors agree everywhere except the final partial interval.
+    np.testing.assert_allclose(
+        np.asarray(duration_mass[:-1]), np.asarray(flat_mass[:-1]), rtol=1e-5
+    )
+    assert float(duration_mass[-1]) < float(flat_mass[-1])
+
+
+def test_model_forward_matches_simulate_puff_on_partial_window():
+    # End-to-end: the model's forward (shared-solve + duration-weighted mass)
+    # must reproduce the trusted `simulate_puff` field, which also weights the
+    # trailing partial puff by its true duration. This ties #32 (mass) and #35
+    # (shared solve) to the reference simulator on a non-multiple window.
+    from plumax.gauss_puff.puff import simulate_puff
+
+    t_end = 40.5  # not a multiple of the 1 s release interval → trailing puff
+    time_array = np.linspace(0.0, t_end, 28, dtype=np.float32)
+    wind_speed = np.full(time_array.shape, 5.0, dtype=np.float32)
+    wind_direction = np.full(time_array.shape, 270.0, dtype=np.float32)
+    source_location = (0.0, 0.0, 2.0)
+    emission_rate = 0.13
+
+    ds = simulate_puff(
+        emission_rate=emission_rate,
+        source_location=source_location,
+        wind_speed=wind_speed,
+        wind_direction=wind_direction,
+        stability_class="C",
+        domain_x=(100.0, 300.0, 5),
+        domain_y=(-20.0, 20.0, 3),
+        domain_z=(0.0, 10.0, 3),
+        time_array=time_array,
+        release_frequency=1.0,
+    )
+
+    # Pick a receptor/time and read the reference concentration off the grid.
+    i_t = len(time_array) - 1
+    x_grid = ds["x"].values
+    y_grid = ds["y"].values
+    z_grid = ds["z"].values
+    i_x, i_y, i_z = 2, 1, 1  # (x=200, y=0, z=5)
+    ref_conc = float(ds["concentration"].values[i_t, i_x, i_y, i_z])
+
+    release_times = make_release_times(0.0, t_end, 1.0)
+    durations = release_durations(release_times, t_end)
+    schedule = WindSchedule.from_speed_direction(time_array, wind_speed, wind_direction)
+    params_dict, dispersion_fn = get_dispersion_scheme("pg")
+    pred = _predict_observations(
+        emission_rate * durations,
+        release_times,
+        (
+            jnp.array([float(x_grid[i_x])]),
+            jnp.array([float(y_grid[i_y])]),
+            jnp.array([float(z_grid[i_z])]),
+        ),
+        jnp.array([float(time_array[i_t])]),
+        source_location,
+        schedule,
+        params_dict["C"],
+        dispersion_fn,
+    )
+    np.testing.assert_allclose(float(pred[0]), ref_conc, rtol=1e-3, atol=1e-12)
+
+
+# ── #34: releases / observations before the wind schedule start raise ─────────
+
+
+def test_infer_rejects_t_start_before_wind_schedule():
+    with pytest.raises(ValueError, match=r"`t_start`.*before the wind schedule"):
+        infer_emission_rate(
+            observations=np.array([1e-6, 2e-6]),
+            observation_coords=(np.array([200.0, 400.0]), np.zeros(2), np.ones(2)),
+            observation_times=np.array([20.0, 25.0]),
+            source_location=(0, 0, 2),
+            wind_times=np.linspace(10.0, 40.0, 4),  # schedule starts at t=10
+            wind_speed=np.full(4, 5.0),
+            wind_direction=np.full(4, 270.0),
+            release_frequency=1.0,
+            t_start=0.0,  # before wind_times[0]
+            t_end=40.0,
+            num_warmup=1,
+            num_samples=1,
+        )
+
+
+def test_infer_rejects_observation_time_before_wind_schedule():
+    with pytest.raises(ValueError, match=r"observation_times.*before"):
+        infer_emission_rate(
+            observations=np.array([1e-6, 2e-6]),
+            observation_coords=(np.array([200.0, 400.0]), np.zeros(2), np.ones(2)),
+            observation_times=np.array([5.0, 25.0]),  # 5.0 precedes wind start
+            source_location=(0, 0, 2),
+            wind_times=np.linspace(10.0, 40.0, 4),  # schedule starts at t=10
+            wind_speed=np.full(4, 5.0),
+            wind_direction=np.full(4, 270.0),
+            release_frequency=1.0,
+            t_start=10.0,  # == wind start, passes the t_start guard
+            t_end=40.0,
             num_warmup=1,
             num_samples=1,
         )


### PR DESCRIPTION
Implements epic #20 — the Gaussian plume/puff correctness and inference-ergonomics cluster — in a single PR.

## #31 — Fix Pasquill-Gifford class-A vertical dispersion coefficient
The class-A `σ_z` `b_z` coefficient was a dropped-digit transcription: `-1.172` instead of the km→m converted McMullen (1975) value `-1.7172`. This inflated `σ_z(1 km, A)` to **~18 km** versus the correct **~418 m** — an order-of-magnitude error in the most-unstable class.

- Corrected the coefficient and documented the McMullen km→m conversion (`ln x_km = ln x_m − ln 1000`) and validity range (~0.1–10 km) on `PG_DISPERSION_PARAMS`.
- Verified against the published curves: classes B–F reproduce the conversion exactly, and class-A `a_z`/`c_z` already matched — only `b_z` was wrong.
- Tests: reference-value pins at 1 km per stability class (`σ = exp(intercept)`), plus a direct class-A anti-regression guard.

## #32 — Conserve emitted mass across partial release intervals
`make_release_times` lays down a release for the final, possibly-partial interval. That trailing puff must carry only its share of emitted mass.

- `gaussian_puff_model` / `gaussian_puff_rw_model` now weight per-puff mass by `release_durations` (`m_i = Q · duration_i`), matching `simulate_puff` and conserving total mass on non-multiple windows.
- Both runners compute and forward `puff_durations` (the timeseries runner previously computed but never passed it).

## #33 — Expose noise-scale knobs on the plume runner
`gauss_plume.infer_emission_rate` now accepts `obs_noise_std` / `background_prior_std` and forwards them to the model, mirroring the puff runner. Posterior width can reflect real sensor noise instead of a hard-coded `5e-7`.

## #34 — Fail fast on out-of-schedule times
The puff inference validator now rejects `t_start` / observation times that precede the wind-schedule start, replacing an opaque diffrax error deep in the trace with a clear message.

## #35 — Solve the shared wind integrals once
`_predict_observations` solves the cumulative wind integrals **once** over `release ∪ observation` times and gathers per observation, instead of one adaptive ODE solve per observation per likelihood evaluation. Same integrals to solver tolerance — verified against the per-observation `evolve_puffs` path and against `simulate_puff`.

## Testing
- `tests/gauss_puff/test_dispersion.py` — 1 km reference pins + class-A physical-range guard.
- `tests/gauss_puff/test_inference.py` — shared-solve equivalence to `evolve_puffs`; partial-interval mass weighting; forward matches `simulate_puff` on a non-multiple window; out-of-schedule `t_start` / observation-time rejection.
- `tests/gauss_plume/test_inference.py` — `obs_noise_std` / `background_prior_std` passthrough (seeded-trace scale check), non-positive-scale rejection, and a slow posterior-width-scaling check.

Full fast suite green (`gauss_puff` + `gauss_plume`: 118 passed); new slow MCMC tests pass; `ruff check .`, `ruff format --check .`, and `ty check src/plumax` clean.

Closes #31, #32, #33, #34, #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEgZbnU2EmmhBrogbmxa9N

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEgZbnU2EmmhBrogbmxa9N)_