### PR TITLE
fix(lagrangian/assimilation): footprint units + clock, DFS control space, Hanna adapter, config (epic #23)

### DIFF
--- a/src/plumax/assimilation/diagnostics.py
+++ b/src/plumax/assimilation/diagnostics.py
@@ -32,7 +32,7 @@ import numpy as np
 
 
 if TYPE_CHECKING:
-    pass
+    from plumax.assimilation.control import WhiteningTransform
 
 
 def reduced_chi_squared(
@@ -58,8 +58,9 @@ def reduced_chi_squared(
 def degrees_of_freedom_for_signal(
     *,
     hessian_vector_product: Callable[[jax.Array], jax.Array],
-    background_op: lx.AbstractLinearOperator,
     state_size: int,
+    background_op: lx.AbstractLinearOperator | None = None,
+    whitened: bool = False,
     n_probes: int = 32,
     seed: int = 0,
     cg_rtol: float = 1e-6,
@@ -72,19 +73,53 @@ def degrees_of_freedom_for_signal(
     and ``DFS = trace(A)`` measures how many independent pieces of information
     the observations contributed (``DFS = 0`` → no information; ``DFS = N`` →
     observations fully pin the state). The posterior covariance is the
-    inverse Hessian at the optimum, ``Bₐ ≈ Hess⁻¹``, so each Hutchinson probe
-    needs:
+    inverse Hessian at the optimum, ``Bₐ ≈ Hess⁻¹``. Because DFS is invariant
+    under the control-variable change ``δx = U ξ``, the estimate must be
+    computed in the space the supplied ``hessian_vector_product`` lives in —
+    mixing an ξ-space Hessian with a model-space ``B`` gives a wrong answer for
+    any ``B ≠ I``.
 
-    - one ``B⁻¹ z`` via :func:`gaussx.solve` (structured dispatch);
-    - one ``Hess⁻¹ w`` via :func:`lineax.linear_solve` (CG on the HVP).
+    Two modes, one per cost builder:
+
+    - **Model space** (``whitened=False``, the default) — pass the Hessian from
+      :func:`plumax.assimilation.cost.build_cost_x` and ``background_op = B``.
+      Each Hutchinson probe needs one ``B⁻¹ z`` via :func:`gaussx.solve`
+      (structured dispatch) and one ``Hess⁻¹ w`` via CG:
+      ``DFS ≈ E[zᵀz − zᵀ Hess⁻¹ B⁻¹ z]``.
+    - **Whitened space** (``whitened=True``) — pass the Hessian from
+      :func:`plumax.assimilation.cost.build_cost_xi`
+      (``Hess_ξ = I + (HU)ᵀR⁻¹HU``). The whitened prior is the identity, so
+      ``B⁻¹`` drops out: ``DFS ≈ E[zᵀz − zᵀ Hess_ξ⁻¹ z]`` and ``background_op``
+      must be omitted.
 
     Cost per probe: ``O(n_CG · forward)`` — dominated by the CG solve.
 
-    Earlier versions of this function computed ``trace(B · Hess)``, which is
-    not DFS: in the zero-information limit (``Hess = B⁻¹``) it returns ``N``
-    instead of the correct ``0``. See PR-review thread on diagnostics.py.
+    Earlier versions computed ``trace(B · Hess)``, which is not DFS: in the
+    zero-information limit (``Hess = B⁻¹``) it returns ``N`` instead of the
+    correct ``0``. See PR-review thread on diagnostics.py.
     """
-    import gaussx as gx
+    if whitened:
+        if background_op is not None:
+            raise ValueError(
+                "degrees_of_freedom_for_signal: `whitened=True` uses the "
+                "whitened prior B_ξ = I; do not pass `background_op` (the ξ-space "
+                "Hessian already absorbs B via δx = U ξ)."
+            )
+
+        def b_inv(z: jax.Array) -> jax.Array:
+            return z
+    else:
+        if background_op is None:
+            raise ValueError(
+                "degrees_of_freedom_for_signal: model-space mode "
+                "(`whitened=False`) requires `background_op = B`; pass the "
+                "Hessian from build_cost_x, or set `whitened=True` for a "
+                "build_cost_xi (ξ-space) Hessian."
+            )
+        import gaussx as gx
+
+        def b_inv(z: jax.Array) -> jax.Array:
+            return gx.solve(background_op, z)
 
     # Build a CG-solvable operator for ``Hess⁻¹``.
     hess_op = lx.FunctionLinearOperator(
@@ -99,8 +134,8 @@ def degrees_of_freedom_for_signal(
     total = 0.0
     for z in z_batch:
         z_j = jnp.asarray(z, dtype=jnp.float64)
-        # w = B⁻¹ z     (structured dispatch, cheap for Kronecker / low-rank)
-        w = gx.solve(background_op, z_j)
+        # w = B⁻¹ z (model space) or z (whitened, since B_ξ = I).
+        w = b_inv(z_j)
         # u = Hess⁻¹ w  (matrix-free CG)
         u = lx.linear_solve(hess_op, w, solver=cg_solver, throw=False).value
         # zᵀ (I − Bₐ B⁻¹) z ≈ zᵀ z − zᵀ (Hess⁻¹ B⁻¹) z
@@ -112,15 +147,27 @@ def posterior_covariance_proxy(
     *,
     hessian_vector_product: Callable[[jax.Array], jax.Array],
     state_size: int,
+    whitening: WhiteningTransform | None = None,
     cg_rtol: float = 1e-6,
     cg_atol: float = 1e-9,
     cg_max_steps: int = 200,
 ) -> Callable[[jax.Array], jax.Array]:
-    """Return a callable ``v → Bₐ v`` via CG on the Hessian.
+    """Return a callable ``v → Bₐ v`` (model-space posterior covariance) via CG.
 
     ``Bₐ ≈ Hess⁻¹`` is the Laplace-approximation posterior covariance. We
     expose it as a matvec (rather than materialising) so per-pixel variance
     estimates remain ``O(state · cg_iters)`` — fine for moderate scenes.
+
+    Pass the Hessian that matches ``whitening``:
+
+    - ``whitening=None`` (default) — a **model-space** Hessian (from
+      :func:`plumax.assimilation.cost.build_cost_x`); the CG solve returns
+      ``Hess⁻¹ v = Bₐ v`` directly.
+    - a :class:`~plumax.assimilation.control.WhiteningTransform` — a **whitened**
+      Hessian (from :func:`plumax.assimilation.cost.build_cost_xi`), whose
+      inverse is the ξ-space covariance, *not* ``Bₐ``. The model-space
+      covariance is recovered as ``Bₐ = U Hess_ξ⁻¹ Uᵀ``, so each apply
+      un-whitens on both sides: ``v → U (Hess_ξ⁻¹ (Uᵀ v))``.
     """
 
     def matvec(v: jax.Array) -> jax.Array:
@@ -133,14 +180,18 @@ def posterior_covariance_proxy(
     )
 
     def apply(v: jax.Array) -> jax.Array:
+        v = jnp.asarray(v)
+        # Whitened Hessian: Bₐ = U Hess_ξ⁻¹ Uᵀ, so map into ξ-space first.
+        rhs = whitening.project_gradient(v) if whitening is not None else v
         # ``throw=False`` returns the best partial solution at max_steps rather
         # than raising — for diagnostics we'd rather get a noisy estimate than
         # crash the whole notebook on a stiff probe direction.
-        return lx.linear_solve(
+        sol = lx.linear_solve(
             op,
-            jnp.asarray(v),
+            rhs,
             solver=lx.CG(rtol=cg_rtol, atol=cg_atol, max_steps=cg_max_steps),
             throw=False,
         ).value
+        return whitening.apply(sol) if whitening is not None else sol
 
     return apply

--- a/src/plumax/lagrangian/__init__.py
+++ b/src/plumax/lagrangian/__init__.py
@@ -51,11 +51,16 @@ from plumax.lagrangian.particles import (
     uniform_wind,
     wind_from_speed_direction,
 )
-from plumax.lagrangian.turbulence import HomogeneousTurbulence, hanna_profiles
+from plumax.lagrangian.turbulence import (
+    HannaTurbulence,
+    HomogeneousTurbulence,
+    hanna_profiles,
+)
 
 
 __all__ = [
     "GaussianPosterior",
+    "HannaTurbulence",
     "HomogeneousTurbulence",
     "LognormalPosterior",
     "ParticleState",

--- a/src/plumax/lagrangian/footprint.py
+++ b/src/plumax/lagrangian/footprint.py
@@ -20,9 +20,10 @@ and carry units s·kg⁻¹ — a different convention; the consumer
 Backward integration reuses the forward integrator with the mean wind reversed;
 for stationary turbulence the OU velocity process is statistically
 time-reversible, so the same turbulence model applies. For a time-varying mean
-wind the backward trajectory must sample it on the *receptor* clock — at the
-start of each forward interval it undoes, ``receptor_time − τ − Δt`` for
-backward pseudo-time ``τ`` and step ``Δt`` — which ``receptor_time`` supplies.
+wind the backward trajectory undoes the forward intervals in reverse order (the
+partial final interval first) and samples ``−wind`` at each interval's physical
+start time on the *receptor* clock, so it is the exact discrete reverse of a
+forward run — which ``receptor_time`` anchors.
 """
 
 from __future__ import annotations
@@ -96,13 +97,13 @@ def compute_footprint(
         pbl_fraction: Fraction ``f_pbl`` of ``h`` defining the surface layer in
             which surface flux is "seen".
         air_density: Air density ``ρ_air`` [kg/m³].
-        receptor_time: Physical time ``T`` of the receptor observation [s]. The
-            backward step at pseudo-time ``τ`` (duration ``Δt``) samples
-            ``−wind(T − τ − Δt)`` — the start of the forward interval it undoes —
-            so a time-varying ``wind`` is evaluated at the correct physical time
-            and the run is the exact discrete reverse of a forward one. The
-            default ``0.0`` is exact for a stationary ``wind`` (its argument is
-            ignored) and simply reverses it.
+        receptor_time: Physical time ``T`` of the receptor observation [s].
+            Backward steps undo the forward intervals in reverse order (the
+            partial final interval first) and sample ``−wind`` at each interval's
+            physical start time, so a time-varying ``wind`` is evaluated at the
+            correct time and the run is the exact discrete reverse of a forward
+            one. The default ``0.0`` is exact for a stationary ``wind`` (its
+            argument is ignored) and simply reverses it.
         seed: PRNG seed.
 
     Returns:
@@ -116,16 +117,6 @@ def compute_footprint(
     y_c = 0.5 * (y_edges[:-1] + y_edges[1:])
     mix_height = pbl_fraction * pbl_height
 
-    def back_wind(t: jax.Array, dt_i: jax.Array) -> jax.Array:
-        # Sample the mean wind on the receptor clock, at the START of the forward
-        # interval this backward step undoes: the step at pseudo-time ``t`` with
-        # duration ``dt_i`` reverses the forward interval ``[T − t − dt_i,
-        # T − t]``, whose step-start value is ``wind(T − t − dt_i)`` — matching
-        # the step-start sampling of ``integrate_particles``, so the backward run
-        # is the exact discrete reverse of the forward one. Negated for the
-        # reversed trajectory.
-        return -jnp.asarray(wind(receptor_time - t - dt_i))
-
     key = jax.random.PRNGKey(seed)
     key, vkey = jax.random.split(key)
     rec = jnp.asarray(receptor_location, dtype=float)
@@ -137,26 +128,38 @@ def compute_footprint(
     xe, ye = jnp.asarray(x_edges), jnp.asarray(y_edges)
     n_steps = n_steps_for_horizon(t_back, dt)
     keys = jax.random.split(key, n_steps)
-    # Per-step durations summing to exactly ``t_back``: the final step is
+    # Per-step durations summing to exactly ``t_back``: the final forward step is
     # shortened to the remainder when ``t_back`` is not a multiple of ``dt``, so
     # the footprint integrates over the requested horizon rather than
     # ``n_steps * dt`` (which would over-count surface residence).
-    times = dt * jnp.arange(n_steps)
-    dts = step_durations(t_back, dt, n_steps)
+    #
+    # Backward integration undoes the forward intervals in reverse order, so the
+    # first backward step consumes the (possibly partial) *final* forward
+    # interval — hence the reversal. ``wind_starts[j]`` is the physical start
+    # time of the interval step ``j`` undoes; sampling ``−wind(wind_starts[j])``
+    # (step-start, matching ``integrate_particles``) makes the backward run the
+    # exact discrete reverse of the forward one for any horizon.
+    dts = step_durations(t_back, dt, n_steps)[::-1]
+    wind_starts = receptor_time - jnp.cumsum(dts)
     nx, ny = len(x_c), len(y_c)
 
     def body(carry, inputs):
         st, hist = carry
-        t, k, dt_i = inputs
+        t_start, k, dt_i = inputs
         st = langevin_step(
-            st, back_wind(t, dt_i), turbulence, dt_i, k, pbl_height=pbl_height
+            st,
+            -jnp.asarray(wind(t_start)),
+            turbulence,
+            dt_i,
+            k,
+            pbl_height=pbl_height,
         )
         below = st.position[:, 2] < mix_height
         hist = hist + _bin_surface(st.position, xe, ye, below) * dt_i
         return (st, hist), None
 
     (_, residence), _ = jax.lax.scan(
-        body, (state, jnp.zeros((nx, ny))), (times, keys, dts)
+        body, (state, jnp.zeros((nx, ny))), (wind_starts, keys, dts)
     )
 
     # Flux-sensitivity normalisation: residence-time per particle divided by the

--- a/src/plumax/lagrangian/footprint.py
+++ b/src/plumax/lagrangian/footprint.py
@@ -8,11 +8,21 @@ footprint is the particle residence time in the well-mixed surface layer of
 [stohl2005flexpart]):
 
     F(r, s) = (1/N) Σ_particles Σ_steps  1[in column s, z < f_pbl·h] · Δt
-              / (ρ_air · A_cell · f_pbl·h)                          [s·m²·kg⁻¹].
+              / (ρ_air · f_pbl·h)                                   [s·m²·kg⁻¹].
+
+This is the **flux-sensitivity** convention: there is no per-cell-area division,
+so ``F`` is the sensitivity of the receptor value to a surface **flux**
+``q`` in kg·m⁻²·s⁻¹ (``y = Σ_s F(r,s)·q(s)``), matching [stohl2005flexpart]. A
+per-cell *emission-rate* sensitivity (kg/s) would divide by ``A_cell`` as well
+and carry units s·kg⁻¹ — a different convention; the consumer
+:mod:`plumax.lagrangian.inversion` assumes the flux one used here.
 
 Backward integration reuses the forward integrator with the mean wind reversed;
 for stationary turbulence the OU velocity process is statistically
-time-reversible, so the same turbulence model applies.
+time-reversible, so the same turbulence model applies. For a time-varying mean
+wind the backward trajectory must sample it on the *receptor* clock — at
+physical time ``receptor_time − τ`` for backward pseudo-time ``τ`` — which
+``receptor_time`` supplies.
 """
 
 from __future__ import annotations
@@ -67,6 +77,7 @@ def compute_footprint(
     pbl_height: float = 1000.0,
     pbl_fraction: float = 0.5,
     air_density: float = 1.2,
+    receptor_time: float = 0.0,
     seed: int = 0,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Compute a single receptor's surface footprint by backward integration.
@@ -76,7 +87,8 @@ def compute_footprint(
         turbulence: Turbulence model.
         domain_x / domain_y: ``(start, stop, n_cells)`` for the surface grid.
         wind: Forward mean-wind field ``t -> (u, v, w)``; integration reverses
-            it internally.
+            it internally and samples it on the receptor clock (see
+            ``receptor_time``).
         n_particles: Ensemble size.
         t_back: Backward integration time [s].
         dt: Time step [s].
@@ -84,21 +96,29 @@ def compute_footprint(
         pbl_fraction: Fraction ``f_pbl`` of ``h`` defining the surface layer in
             which surface flux is "seen".
         air_density: Air density ``ρ_air`` [kg/m³].
+        receptor_time: Physical time ``T`` of the receptor observation [s]. The
+            backward step at pseudo-time ``τ`` samples ``−wind(T − τ)``, so a
+            time-varying ``wind`` is evaluated at the correct physical time. The
+            default ``0.0`` is exact for a stationary ``wind`` (its argument is
+            ignored) and simply reverses it.
         seed: PRNG seed.
 
     Returns:
         ``(footprint, x_centers, y_centers)`` where ``footprint`` has shape
-        ``(nx, ny)`` and units ``s·m²·kg⁻¹``.
+        ``(nx, ny)`` and units ``s·m²·kg⁻¹`` (flux sensitivity; see the module
+        docstring).
     """
     x_edges = np.linspace(domain_x[0], domain_x[1], int(domain_x[2]) + 1)
     y_edges = np.linspace(domain_y[0], domain_y[1], int(domain_y[2]) + 1)
     x_c = 0.5 * (x_edges[:-1] + x_edges[1:])
     y_c = 0.5 * (y_edges[:-1] + y_edges[1:])
-    cell_area = float((x_edges[1] - x_edges[0]) * (y_edges[1] - y_edges[0]))
     mix_height = pbl_fraction * pbl_height
 
     def back_wind(t: jax.Array) -> jax.Array:
-        return -jnp.asarray(wind(t))
+        # Sample the mean wind on the receptor clock: at backward pseudo-time
+        # ``t`` the physical time is ``receptor_time − t``. Reversed for the
+        # backward trajectory.
+        return -jnp.asarray(wind(receptor_time - t))
 
     key = jax.random.PRNGKey(seed)
     key, vkey = jax.random.split(key)
@@ -131,9 +151,10 @@ def compute_footprint(
         body, (state, jnp.zeros((nx, ny))), (times, keys, dts)
     )
 
-    footprint = np.asarray(residence) / (
-        n_particles * air_density * cell_area * mix_height
-    )
+    # Flux-sensitivity normalisation: residence-time per particle divided by the
+    # surface-layer air mass column density ρ·h (no per-cell-area division), so
+    # ``F`` has units s·m²·kg⁻¹ and pairs with a surface flux in kg·m⁻²·s⁻¹.
+    footprint = np.asarray(residence) / (n_particles * air_density * mix_height)
     return footprint, x_c, y_c
 
 

--- a/src/plumax/lagrangian/footprint.py
+++ b/src/plumax/lagrangian/footprint.py
@@ -20,9 +20,9 @@ and carry units s·kg⁻¹ — a different convention; the consumer
 Backward integration reuses the forward integrator with the mean wind reversed;
 for stationary turbulence the OU velocity process is statistically
 time-reversible, so the same turbulence model applies. For a time-varying mean
-wind the backward trajectory must sample it on the *receptor* clock — at
-physical time ``receptor_time − τ`` for backward pseudo-time ``τ`` — which
-``receptor_time`` supplies.
+wind the backward trajectory must sample it on the *receptor* clock — at the
+start of each forward interval it undoes, ``receptor_time − τ − Δt`` for
+backward pseudo-time ``τ`` and step ``Δt`` — which ``receptor_time`` supplies.
 """
 
 from __future__ import annotations
@@ -97,8 +97,10 @@ def compute_footprint(
             which surface flux is "seen".
         air_density: Air density ``ρ_air`` [kg/m³].
         receptor_time: Physical time ``T`` of the receptor observation [s]. The
-            backward step at pseudo-time ``τ`` samples ``−wind(T − τ)``, so a
-            time-varying ``wind`` is evaluated at the correct physical time. The
+            backward step at pseudo-time ``τ`` (duration ``Δt``) samples
+            ``−wind(T − τ − Δt)`` — the start of the forward interval it undoes —
+            so a time-varying ``wind`` is evaluated at the correct physical time
+            and the run is the exact discrete reverse of a forward one. The
             default ``0.0`` is exact for a stationary ``wind`` (its argument is
             ignored) and simply reverses it.
         seed: PRNG seed.
@@ -114,11 +116,15 @@ def compute_footprint(
     y_c = 0.5 * (y_edges[:-1] + y_edges[1:])
     mix_height = pbl_fraction * pbl_height
 
-    def back_wind(t: jax.Array) -> jax.Array:
-        # Sample the mean wind on the receptor clock: at backward pseudo-time
-        # ``t`` the physical time is ``receptor_time − t``. Reversed for the
-        # backward trajectory.
-        return -jnp.asarray(wind(receptor_time - t))
+    def back_wind(t: jax.Array, dt_i: jax.Array) -> jax.Array:
+        # Sample the mean wind on the receptor clock, at the START of the forward
+        # interval this backward step undoes: the step at pseudo-time ``t`` with
+        # duration ``dt_i`` reverses the forward interval ``[T − t − dt_i,
+        # T − t]``, whose step-start value is ``wind(T − t − dt_i)`` — matching
+        # the step-start sampling of ``integrate_particles``, so the backward run
+        # is the exact discrete reverse of the forward one. Negated for the
+        # reversed trajectory.
+        return -jnp.asarray(wind(receptor_time - t - dt_i))
 
     key = jax.random.PRNGKey(seed)
     key, vkey = jax.random.split(key)
@@ -142,7 +148,9 @@ def compute_footprint(
     def body(carry, inputs):
         st, hist = carry
         t, k, dt_i = inputs
-        st = langevin_step(st, back_wind(t), turbulence, dt_i, k, pbl_height=pbl_height)
+        st = langevin_step(
+            st, back_wind(t, dt_i), turbulence, dt_i, k, pbl_height=pbl_height
+        )
         below = st.position[:, 2] < mix_height
         hist = hist + _bin_surface(st.position, xe, ye, below) * dt_i
         return (st, hist), None

--- a/src/plumax/lagrangian/inversion.py
+++ b/src/plumax/lagrangian/inversion.py
@@ -5,6 +5,12 @@ from a discretised emission field ``q`` to predicted observations
 ``y_pred = F q`` (see :func:`plumax.lagrangian.compute_footprint`) — this module
 recovers a Bayesian posterior over ``q`` from observed column enhancements.
 
+Units follow ``F``'s flux-sensitivity convention (s·m²·kg⁻¹, see
+:func:`plumax.lagrangian.compute_footprint`): ``q`` is a per-cell surface
+**flux** in kg·m⁻²·s⁻¹, and the prior mean / covariance are expressed in those
+same flux units. The estimators are unit-agnostic — they only require ``q`` and
+``F`` to be mutually consistent so that ``F q`` lands in the observation units.
+
 Two estimators, both following the Tier II design note
 ([design](https://github.com/jejjohnson/plumax/blob/main/docs/design/02_tier2_lagrangian.md#tier2-inference)):
 

--- a/src/plumax/lagrangian/particles.py
+++ b/src/plumax/lagrangian/particles.py
@@ -18,7 +18,9 @@ well mixed (stationary velocity variance ``σ²`` with no time-step bias), and
 adds the inhomogeneous vertical drift correction with an Euler step. The
 correction's ``∂σ_w²/∂z`` is obtained by autodiff of the turbulence profile, so
 it is zero for :class:`~plumax.lagrangian.turbulence.HomogeneousTurbulence` and
-nonzero for :func:`~plumax.lagrangian.turbulence.hanna_profiles` automatically.
+nonzero for :class:`~plumax.lagrangian.turbulence.HannaTurbulence` (the
+``at``-exposing adapter over
+:func:`~plumax.lagrangian.turbulence.hanna_profiles`) automatically.
 
 Vertical motion reflects off the ground (``z = 0``) and, when a boundary-layer
 height is supplied, off the PBL top — flipping both ``z`` and ``v_w``.

--- a/src/plumax/lagrangian/turbulence.py
+++ b/src/plumax/lagrangian/turbulence.py
@@ -179,4 +179,44 @@ def hanna_profiles(
     return sigma, tau
 
 
-__all__ = ["HomogeneousTurbulence", "hanna_profiles"]
+@dataclass(frozen=True)
+class HannaTurbulence:
+    """Height-dependent Hanna (1982) turbulence as a ``TurbulenceModel``.
+
+    Thin adapter that binds the surface-layer scales required by
+    :func:`hanna_profiles` and exposes the ``at(z) -> (sigma, tau)`` interface
+    the integrator (:func:`plumax.lagrangian.langevin_step`,
+    :func:`~plumax.lagrangian.integrate_particles`,
+    :func:`~plumax.lagrangian.compute_footprint`) expects. Because ``σ_w`` varies
+    with height, the well-mixed vertical drift correction ``½(1+v_w²/σ_w²)
+    ∂σ_w²/∂z`` is non-zero — the inhomogeneous path that
+    :class:`HomogeneousTurbulence` never exercises.
+
+    Attributes:
+        u_star: Friction velocity ``u_*`` [m/s].
+        pbl_height: Boundary-layer height ``h`` [m].
+        obukhov_length: Monin–Obukhov length ``L`` [m] (``< 0`` unstable).
+        w_star: Convective velocity scale ``w_*`` [m/s] (used when ``L < 0``).
+    """
+
+    u_star: float
+    pbl_height: float
+    obukhov_length: float
+    w_star: float = 0.0
+
+    def at(self, z: jax.Array) -> tuple[jax.Array, jax.Array]:
+        """Return ``(σ, τ_L)`` at height(s) ``z`` from the Hanna (1982) profiles.
+
+        ``σ`` and ``τ_L`` have a trailing axis of size 3, matching
+        :meth:`HomogeneousTurbulence.at`.
+        """
+        return hanna_profiles(
+            z,
+            u_star=self.u_star,
+            pbl_height=self.pbl_height,
+            obukhov_length=self.obukhov_length,
+            w_star=self.w_star,
+        )
+
+
+__all__ = ["HannaTurbulence", "HomogeneousTurbulence", "hanna_profiles"]

--- a/src/plumax/lagrangian/turbulence.py
+++ b/src/plumax/lagrangian/turbulence.py
@@ -197,19 +197,35 @@ class HannaTurbulence:
         pbl_height: Boundary-layer height ``h`` [m].
         obukhov_length: Monin–Obukhov length ``L`` [m] (``< 0`` unstable).
         w_star: Convective velocity scale ``w_*`` [m/s] (used when ``L < 0``).
+        z_floor: Minimum height [m] at which the profiles are evaluated. The
+            convective ``σ_w²`` term carries a ``(z/h)^{2/3}`` factor whose
+            ``∂/∂z`` is singular at the ground, so the integrator's well-mixed
+            drift ``½(1+v_w²/σ_w²)∂σ_w²/∂z`` would be ``inf``/``NaN`` for a
+            ground-level source or a particle reflected exactly to ``z = 0``.
+            Flooring ``z`` keeps the drift finite; the default ``0.1 m`` sits at
+            the roughness / surface-layer scale where the similarity profiles are
+            not valid anyway.
     """
 
     u_star: float
     pbl_height: float
     obukhov_length: float
     w_star: float = 0.0
+    z_floor: float = 0.1
+
+    def __post_init__(self) -> None:
+        if not (self.z_floor > 0.0):
+            raise ValueError("HannaTurbulence: `z_floor` must be > 0")
 
     def at(self, z: jax.Array) -> tuple[jax.Array, jax.Array]:
         """Return ``(σ, τ_L)`` at height(s) ``z`` from the Hanna (1982) profiles.
 
-        ``σ`` and ``τ_L`` have a trailing axis of size 3, matching
+        ``z`` is floored at :attr:`z_floor` before evaluation so the vertical
+        drift stays finite at the ground (see the class docstring). ``σ`` and
+        ``τ_L`` have a trailing axis of size 3, matching
         :meth:`HomogeneousTurbulence.at`.
         """
+        z = jnp.maximum(jnp.asarray(z, dtype=float), self.z_floor)
         return hanna_profiles(
             z,
             u_star=self.u_star,

--- a/src/plumax/operators.py
+++ b/src/plumax/operators.py
@@ -255,14 +255,20 @@ class LagrangianDispersion(Operator):
         )
 
     def get_config(self) -> dict[str, Any]:
+        # Mirror the constructor surface (minus the non-serialisable
+        # ``turbulence`` object). The old payload emitted a bogus
+        # ``stability_class`` key — not a constructor parameter — and dropped
+        # ``pbl_height`` / ``background_conc`` / ``seed``.
         return {
-            "stability_class": None,
             "domain_x": self.domain_x,
             "domain_y": self.domain_y,
             "domain_z": self.domain_z,
             "n_particles": self.n_particles,
             "t_end": self.t_end,
             "dt": self.dt,
+            "pbl_height": self.pbl_height,
+            "background_conc": self.background_conc,
+            "seed": self.seed,
         }
 
 

--- a/tests/assimilation/test_diagnostics.py
+++ b/tests/assimilation/test_diagnostics.py
@@ -246,9 +246,12 @@ def test_posterior_covariance_proxy_runs(obs_model_no_optics):
         observation=y,
         state_shape=(ny, nx),
     )
+    # The HVP is whitened (build_cost_xi), so pass `whitening` to get the
+    # model-space covariance Bₐ = U Hess_ξ⁻¹ Uᵀ rather than the raw ξ-space one.
     matvec = posterior_covariance_proxy(
         hessian_vector_product=lambda v: cost.hvp(jnp.zeros(ny * nx), v),
         state_size=ny * nx,
+        whitening=W,
         cg_max_steps=50,
     )
     Bv = matvec(jnp.ones(ny * nx))

--- a/tests/assimilation/test_diagnostics.py
+++ b/tests/assimilation/test_diagnostics.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from plumax.assimilation.background import build_diagonal_background
 from plumax.assimilation.control import WhiteningTransform
-from plumax.assimilation.cost import build_cost_xi
+from plumax.assimilation.cost import build_cost_x, build_cost_xi
 from plumax.assimilation.diagnostics import (
     degrees_of_freedom_for_signal,
     posterior_covariance_proxy,
@@ -60,8 +61,8 @@ def test_dfs_zero_in_no_information_limit(obs_model_no_optics):
     )
     dfs = degrees_of_freedom_for_signal(
         hessian_vector_product=lambda v: cost.hvp(jnp.zeros(ny * nx), v),
-        background_op=B,
         state_size=ny * nx,
+        whitened=True,  # cost is build_cost_xi → ξ-space Hessian, prior = I
         n_probes=8,
     )
     assert np.isfinite(dfs)
@@ -88,12 +89,147 @@ def test_dfs_approaches_state_size_in_high_information_limit(obs_model_no_optics
     )
     dfs = degrees_of_freedom_for_signal(
         hessian_vector_product=lambda v: cost.hvp(jnp.zeros(ny * nx), v),
-        background_op=B,
         state_size=ny * nx,
+        whitened=True,  # cost is build_cost_xi → ξ-space Hessian, prior = I
         n_probes=16,
     )
     # Should be close to state_size = 9; allow Hutchinson + CG slack.
     assert 7.0 < dfs < ny * nx + 0.5
+
+
+def test_dfs_nonidentity_background(obs_model_no_optics):
+    """DFS agrees between the model-space and whitened paths for B ≠ I.
+
+    The old code combined a ξ-space Hessian with a model-space B⁻¹ solve, which
+    is only correct when B = I. Here B is strongly heteroscedastic, so the two
+    paths must be computed in their own spaces (``whitened`` flag) to agree —
+    and both must match an exact dense reference.
+    """
+    model = obs_model_no_optics
+    ny, nx = 3, 3
+    n = ny * nx
+    # Wide, non-uniform prior variances → B ≠ I in a way that the space-mixing
+    # bug cannot hide behind.
+    variances = np.array([0.05, 0.1, 0.3, 0.7, 1.0, 1.5, 3.0, 6.0, 12.0])
+    B = build_diagonal_background(variances)
+    W = WhiteningTransform.from_background(B)
+    fwd = model.make_forward(linear=False)
+    y = model.forward(jnp.full((ny, nx), 1e-7), linear=False)
+    obs_inv = 1e-11  # partial-information regime (chosen so 0 < DFS < n)
+
+    kw = dict(
+        forward_fn=fwd,
+        obs_inv_variance=obs_inv,
+        background_state=jnp.zeros((ny, nx)),
+        observation=y,
+        state_shape=(ny, nx),
+    )
+    cost_x = build_cost_x(background_op=B, **kw)
+    cost_xi = build_cost_xi(whitening=W, **kw)
+
+    dfs_x = degrees_of_freedom_for_signal(
+        hessian_vector_product=lambda v: cost_x.hvp(jnp.zeros(n), v),
+        state_size=n,
+        background_op=B,
+        whitened=False,
+        n_probes=64,
+        seed=0,
+    )
+    dfs_xi = degrees_of_freedom_for_signal(
+        hessian_vector_product=lambda v: cost_xi.hvp(jnp.zeros(n), v),
+        state_size=n,
+        whitened=True,
+        n_probes=64,
+        seed=0,
+    )
+
+    # Exact reference: dense ξ-space Hessian, DFS = n − trace(Hess_ξ⁻¹).
+    basis = np.eye(n)
+    hess_xi = np.stack(
+        [np.asarray(cost_xi.hvp(jnp.zeros(n), jnp.asarray(col))) for col in basis],
+        axis=1,
+    )
+    hess_xi_inv = np.linalg.inv(hess_xi)
+    exact = n - np.trace(hess_xi_inv)
+
+    # The setup must be genuinely partial for the test to exercise the bug.
+    assert 0.5 < exact < n - 0.5
+    np.testing.assert_allclose(dfs_x, exact, atol=0.6)
+    np.testing.assert_allclose(dfs_xi, exact, atol=0.6)
+    np.testing.assert_allclose(dfs_x, dfs_xi, atol=0.8)
+
+    # Non-vacuous: the old ξ-hvp + B⁻¹ mix gives a materially different number.
+    buggy = n - np.trace(hess_xi_inv @ np.diag(1.0 / variances))
+    assert abs(exact - buggy) > 0.5
+
+
+def test_dfs_rejects_inconsistent_background_args(obs_model_no_optics):
+    model = obs_model_no_optics
+    ny, nx = 3, 3
+    B = build_diagonal_background(1.0, n_pixels=ny * nx)
+    W = WhiteningTransform.from_background(B)
+    y = model.forward(jnp.zeros((ny, nx)), linear=False)
+    cost = build_cost_xi(
+        forward_fn=model.make_forward(linear=False),
+        whitening=W,
+        obs_inv_variance=1.0,
+        background_state=jnp.zeros((ny, nx)),
+        observation=y,
+        state_shape=(ny, nx),
+    )
+    hvp = lambda v: cost.hvp(jnp.zeros(ny * nx), v)
+    with pytest.raises(ValueError, match=r"whitened=True.*do not pass `background_op`"):
+        degrees_of_freedom_for_signal(
+            hessian_vector_product=hvp,
+            state_size=ny * nx,
+            background_op=B,
+            whitened=True,
+            n_probes=2,
+        )
+    with pytest.raises(ValueError, match=r"model-space mode.*requires"):
+        degrees_of_freedom_for_signal(
+            hessian_vector_product=hvp,
+            state_size=ny * nx,
+            whitened=False,
+            n_probes=2,
+        )
+
+
+def test_posterior_covariance_proxy_whitened_matches_model_space(obs_model_no_optics):
+    """Bₐ = U Hess_ξ⁻¹ Uᵀ: the whitened proxy reproduces the model-space one."""
+    model = obs_model_no_optics
+    ny, nx = 3, 3
+    n = ny * nx
+    variances = np.array([0.05, 0.2, 0.5, 0.8, 1.0, 1.3, 2.0, 4.0, 9.0])
+    B = build_diagonal_background(variances)
+    W = WhiteningTransform.from_background(B)
+    fwd = model.make_forward(linear=False)
+    y = model.forward(jnp.full((ny, nx), 1e-7), linear=False)
+    kw = dict(
+        forward_fn=fwd,
+        obs_inv_variance=1e-11,
+        background_state=jnp.zeros((ny, nx)),
+        observation=y,
+        state_shape=(ny, nx),
+    )
+    cost_x = build_cost_x(background_op=B, **kw)
+    cost_xi = build_cost_xi(whitening=W, **kw)
+
+    proxy_x = posterior_covariance_proxy(
+        hessian_vector_product=lambda v: cost_x.hvp(jnp.zeros(n), v),
+        state_size=n,
+        cg_max_steps=500,
+    )
+    proxy_xi = posterior_covariance_proxy(
+        hessian_vector_product=lambda v: cost_xi.hvp(jnp.zeros(n), v),
+        state_size=n,
+        whitening=W,
+        cg_max_steps=500,
+    )
+    v = jnp.asarray(np.linspace(-1.0, 1.0, n))
+    np.testing.assert_allclose(
+        np.asarray(proxy_xi(v)), np.asarray(proxy_x(v)), rtol=1e-3, atol=1e-8
+    )
 
 
 def test_posterior_covariance_proxy_runs(obs_model_no_optics):

--- a/tests/lagrangian/test_footprint.py
+++ b/tests/lagrangian/test_footprint.py
@@ -181,11 +181,12 @@ def test_time_varying_wind_clock():
         return float((x_c * w).sum() / w.sum())
 
     x_ok, x_bad = centroid(fp_ok), centroid(fp_bad)
-    # Correct clock retraces the forward path (the residual few-% gap is the
-    # forward-Euler half-step sampling asymmetry, not the clock); the wrong clock
-    # samples the slow early winds, under-displaces, and sits well downwind.
-    np.testing.assert_allclose(x_ok, x_ref, rtol=0.05)
-    assert x_bad > x_ok + 20.0
+    # Correct clock is the exact discrete reverse of the forward run, so its
+    # footprint centroid matches the forward path to binning resolution; a wrong
+    # receptor clock samples the wind at the wrong physical times and lands a
+    # materially different centroid.
+    np.testing.assert_allclose(x_ok, x_ref, rtol=0.02)
+    assert abs(x_ok - x_bad) > 20.0
 
 
 def test_footprint_scales_inversely_with_air_density():

--- a/tests/lagrangian/test_footprint.py
+++ b/tests/lagrangian/test_footprint.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
 from plumax.lagrangian.footprint import compute_footprint
-from plumax.lagrangian.particles import wind_from_speed_direction
+from plumax.lagrangian.particles import (
+    ParticleState,
+    integrate_particles,
+    wind_from_speed_direction,
+)
 from plumax.lagrangian.turbulence import HomogeneousTurbulence
 
 
@@ -16,14 +21,14 @@ def _turb():
 
 
 def test_footprint_integrates_requested_horizon_for_partial_step():
-    # Σ footprint · (ρ · A_cell · mix_height) = total surface residence time,
-    # which equals t_back when every particle stays below the mixing height and
-    # inside the domain. A non-divisible horizon (t_back=60.5, dt=1) must give
-    # 60.5 s, not the 61 s a ceil'd full-dt accumulation would.
+    # Flux-sensitivity convention (units s·m²·kg⁻¹): Σ footprint · (ρ · mix_height)
+    # = total surface residence time — no cell-area factor — which equals t_back
+    # when every particle stays below the mixing height and inside the domain. A
+    # non-divisible horizon (t_back=60.5, dt=1) must give 60.5 s, not the 61 s a
+    # ceil'd full-dt accumulation would.
     rho, t_back = 1.2, 60.5
     pbl_height, pbl_fraction = 2000.0, 0.5
     mix_height = pbl_fraction * pbl_height
-    dx, dy = 1000.0 / 40, 1000.0 / 40
     fp, _, _ = compute_footprint(
         (0.0, 0.0, 20.0),
         HomogeneousTurbulence.isotropic(sigma=0.5, tau=30.0),
@@ -38,8 +43,47 @@ def test_footprint_integrates_requested_horizon_for_partial_step():
         air_density=rho,
         seed=0,
     )
-    total_residence = float(fp.sum()) * rho * (dx * dy) * mix_height
+    total_residence = float(fp.sum()) * rho * mix_height
     assert total_residence == pytest.approx(t_back, rel=1e-3)
+
+
+def test_footprint_units_convention():
+    # Pin the flux-sensitivity convention dimensionally. Halving either the air
+    # density or the mixing-layer depth doubles the footprint (F ∝ 1/(ρ·f·h)),
+    # and there is NO dependence on the surface cell area — the distinguishing
+    # property of s·m²·kg⁻¹ (flux) vs s·kg⁻¹ (per-cell rate, which would scale
+    # with 1/A_cell). Same calm setup, so total residence is conserved.
+    turb = HomogeneousTurbulence.isotropic(sigma=0.5, tau=30.0)
+    base = dict(
+        receptor_location=(0.0, 0.0, 20.0),
+        turbulence=turb,
+        wind=lambda t: jnp.zeros(3),
+        n_particles=3000,
+        t_back=60.0,
+        dt=1.0,
+        pbl_height=2000.0,
+        pbl_fraction=0.5,
+        air_density=1.2,
+        seed=0,
+    )
+    fp_ref, _, _ = compute_footprint(
+        domain_x=(-500.0, 500.0, 40), domain_y=(-500.0, 500.0, 40), **base
+    )
+    # Coarser grid → 4× larger cells. Flux sensitivity total is invariant to the
+    # cell size (up to which cells particles land in); a per-cell-rate footprint
+    # would instead scale each cell by 1/A_cell and change the sum.
+    fp_coarse, _, _ = compute_footprint(
+        domain_x=(-500.0, 500.0, 20), domain_y=(-500.0, 500.0, 20), **base
+    )
+    np.testing.assert_allclose(fp_ref.sum(), fp_coarse.sum(), rtol=1e-6)
+
+    # Halving ρ or the mixing depth doubles F.
+    fp_half_rho, _, _ = compute_footprint(
+        domain_x=(-500.0, 500.0, 40),
+        domain_y=(-500.0, 500.0, 40),
+        **{**base, "air_density": 0.6},
+    )
+    np.testing.assert_allclose(fp_half_rho, 2.0 * fp_ref, rtol=1e-6)
 
 
 def test_footprint_shape_and_nonnegative():
@@ -81,6 +125,67 @@ def test_footprint_lies_upwind_of_receptor():
     weights = fp.sum(axis=1)
     x_centroid = float((x * weights).sum() / weights.sum())
     assert x_centroid < receptor_x
+
+
+def test_time_varying_wind_clock():
+    # For deterministic advection the backward trajectory from a receptor at
+    # physical time T is the exact time-reverse of a forward trajectory that
+    # arrives there at T. With a strongly time-varying (accelerating) wind this
+    # only holds if the backward step samples the wind on the receptor clock,
+    # -wind(T - τ). We forward-integrate a particle to fix the receptor, then
+    # check the backward footprint retraces the forward path — and that the old
+    # forward-clock behaviour (receptor_time=0) does not.
+    calm = HomogeneousTurbulence(0.0, 0.0, 0.0, 100.0, 100.0, 100.0)
+    t_back = 60.0
+
+    def wind(t):
+        # Accelerating along +x: u sweeps 1 → 7 m/s over [0, T].
+        return jnp.array([1.0 + 0.1 * t, 0.0, 0.0])
+
+    # Forward reference: a particle from the source lands at the receptor at T.
+    src = (0.0, 0.0, 20.0)
+    state0 = ParticleState(position=jnp.array([[*src]]), velocity=jnp.zeros((1, 3)))
+    final, traj = integrate_particles(
+        state0,
+        wind,
+        calm,
+        t0=0.0,
+        t1=t_back,
+        dt=1.0,
+        key=jax.random.PRNGKey(0),
+        save_trajectory=True,
+    )
+    receptor_x = float(final.position[0, 0])
+    # The backward run bins the position after each step, visiting (in reverse)
+    # the forward positions p₀…pₙ₋₁ — i.e. the source up to just-before-receptor.
+    # Compare against that dt-weighted x-centroid of the forward path.
+    x_ref = float(np.asarray(traj[:-1, 0, 0]).mean())
+
+    common = dict(
+        receptor_location=(receptor_x, 0.0, 20.0),
+        turbulence=calm,
+        domain_x=(-100.0, 400.0, 100),
+        domain_y=(-50.0, 50.0, 10),
+        wind=wind,
+        n_particles=200,
+        t_back=t_back,
+        dt=1.0,
+        pbl_height=2000.0,
+        seed=0,
+    )
+    fp_ok, x_c, _ = compute_footprint(receptor_time=t_back, **common)
+    fp_bad, _, _ = compute_footprint(receptor_time=0.0, **common)
+
+    def centroid(fp):
+        w = fp.sum(axis=1)
+        return float((x_c * w).sum() / w.sum())
+
+    x_ok, x_bad = centroid(fp_ok), centroid(fp_bad)
+    # Correct clock retraces the forward path (the residual few-% gap is the
+    # forward-Euler half-step sampling asymmetry, not the clock); the wrong clock
+    # samples the slow early winds, under-displaces, and sits well downwind.
+    np.testing.assert_allclose(x_ok, x_ref, rtol=0.05)
+    assert x_bad > x_ok + 20.0
 
 
 def test_footprint_scales_inversely_with_air_density():

--- a/tests/lagrangian/test_footprint.py
+++ b/tests/lagrangian/test_footprint.py
@@ -11,6 +11,8 @@ from plumax.lagrangian.footprint import compute_footprint
 from plumax.lagrangian.particles import (
     ParticleState,
     integrate_particles,
+    n_steps_for_horizon,
+    step_durations,
     wind_from_speed_direction,
 )
 from plumax.lagrangian.turbulence import HomogeneousTurbulence
@@ -127,16 +129,18 @@ def test_footprint_lies_upwind_of_receptor():
     assert x_centroid < receptor_x
 
 
-def test_time_varying_wind_clock():
+@pytest.mark.parametrize("t_back", [60.0, 60.5])
+def test_time_varying_wind_clock(t_back):
     # For deterministic advection the backward trajectory from a receptor at
-    # physical time T is the exact time-reverse of a forward trajectory that
+    # physical time T is the exact discrete reverse of a forward trajectory that
     # arrives there at T. With a strongly time-varying (accelerating) wind this
-    # only holds if the backward step samples the wind on the receptor clock,
-    # -wind(T - τ). We forward-integrate a particle to fix the receptor, then
-    # check the backward footprint retraces the forward path — and that the old
-    # forward-clock behaviour (receptor_time=0) does not.
+    # only holds if the backward run undoes the forward intervals in reverse
+    # order (partial remainder first) and samples each at its physical start
+    # time on the receptor clock. A non-divisible t_back (60.5) exercises the
+    # remainder-first ordering. We forward-integrate a particle to fix the
+    # receptor, then check the backward footprint retraces the forward path —
+    # and that a wrong receptor clock (receptor_time=0) does not.
     calm = HomogeneousTurbulence(0.0, 0.0, 0.0, 100.0, 100.0, 100.0)
-    t_back = 60.0
 
     def wind(t):
         # Accelerating along +x: u sweeps 1 → 7 m/s over [0, T].
@@ -156,10 +160,12 @@ def test_time_varying_wind_clock():
         save_trajectory=True,
     )
     receptor_x = float(final.position[0, 0])
-    # The backward run bins the position after each step, visiting (in reverse)
-    # the forward positions p₀…pₙ₋₁ — i.e. the source up to just-before-receptor.
-    # Compare against that dt-weighted x-centroid of the forward path.
-    x_ref = float(np.asarray(traj[:-1, 0, 0]).mean())
+    # The backward run bins (in reverse) the forward positions p₀…pₙ₋₁, each
+    # weighted by its forward step duration. Compare against that duration-
+    # weighted x-centroid of the forward path.
+    n = n_steps_for_horizon(t_back, 1.0)
+    dts = np.asarray(step_durations(t_back, 1.0, n))
+    x_ref = float((dts * np.asarray(traj[:-1, 0, 0])).sum() / dts.sum())
 
     common = dict(
         receptor_location=(receptor_x, 0.0, 20.0),

--- a/tests/lagrangian/test_operator.py
+++ b/tests/lagrangian/test_operator.py
@@ -44,3 +44,29 @@ def test_lagrangian_operator_config_reports_keys():
     cfg = op.get_config()
     assert cfg["n_particles"] == 5000
     assert cfg["domain_x"] == (0.0, 100.0, 10)
+
+
+def test_lagrangian_dispersion_config_keys():
+    # Regression for #52: the config payload must reflect the real constructor
+    # surface — no bogus `stability_class` key (a GaussianPlume copy-paste), and
+    # the previously-dropped pbl_height / background_conc / seed present.
+    import inspect
+
+    op = LagrangianDispersion(
+        turbulence=HomogeneousTurbulence.isotropic(1.0, 30.0),
+        domain_x=(0.0, 100.0, 10),
+        domain_y=(0.0, 100.0, 10),
+        domain_z=(0.0, 100.0, 10),
+        pbl_height=800.0,
+        background_conc=1e-9,
+        seed=7,
+    )
+    cfg = op.get_config()
+    ctor_params = set(inspect.signature(LagrangianDispersion.__init__).parameters)
+    # Every reported key is a real constructor parameter.
+    assert set(cfg) <= ctor_params
+    assert "stability_class" not in cfg
+    # The real fields round-trip.
+    assert cfg["pbl_height"] == 800.0
+    assert cfg["background_conc"] == 1e-9
+    assert cfg["seed"] == 7

--- a/tests/lagrangian/test_particles.py
+++ b/tests/lagrangian/test_particles.py
@@ -16,7 +16,7 @@ from plumax.lagrangian.particles import (
     uniform_wind,
     wind_from_speed_direction,
 )
-from plumax.lagrangian.turbulence import HomogeneousTurbulence
+from plumax.lagrangian.turbulence import HannaTurbulence, HomogeneousTurbulence
 
 
 @pytest.mark.parametrize(
@@ -159,6 +159,50 @@ def test_wind_from_speed_direction_west_wind_flows_east():
     wind = wind_from_speed_direction(5.0, 270.0)
     vec = np.asarray(wind(jnp.array(0.0)))
     np.testing.assert_allclose(vec, [5.0, 0.0, 0.0], atol=1e-6)
+
+
+def test_well_mixed_condition_hanna():
+    """An initially uniform slab stays uniform under inhomogeneous Hanna turbulence.
+
+    This is the well-mixed criterion (Thomson 1987): with height-dependent
+    ``σ_w(z)`` the integrator's drift correction ``½(1+v_w²/σ_w²)∂σ_w²/∂z`` is
+    what stops particles from piling up where the turbulence is weak. It is
+    unreachable with :class:`HomogeneousTurbulence` (zero gradient); the
+    :class:`HannaTurbulence` adapter is exactly what exercises it.
+    """
+    turb = HannaTurbulence(
+        u_star=0.5, pbl_height=1000.0, obukhov_length=-50.0, w_star=2.0
+    )  # convective → σ_w varies strongly with height
+    h = 1000.0
+    n = 8000
+    key = jax.random.PRNGKey(0)
+    key, zkey, vkey = jax.random.split(key, 3)
+    # Uniform in z, velocities drawn from the *local* stationary variance.
+    z0 = jax.random.uniform(zkey, (n,), minval=0.0, maxval=h)
+    pos = jnp.stack([jnp.zeros(n), jnp.zeros(n), z0], axis=1)
+    sigma0, _ = turb.at(z0)
+    vel = jax.random.normal(vkey, (n, 3)) * sigma0
+    state = ParticleState(position=pos, velocity=vel)
+
+    final, _ = integrate_particles(
+        state,
+        uniform_wind(0.0, 0.0, 0.0),
+        turb,
+        t0=0.0,
+        t1=400.0,
+        dt=1.0,
+        key=key,
+        pbl_height=h,
+    )
+    zf = np.asarray(final.position[:, 2])
+    assert np.all(zf >= -1e-6)
+    assert np.all(zf <= h + 1e-6)
+    # Still uniform: per-bin occupancy within ~20 % of N/nbins, and the mean
+    # near the slab centre (no collapse toward the low-σ_w upper layer).
+    counts, _ = np.histogram(zf, bins=5, range=(0.0, h))
+    expected = n / 5
+    assert np.max(np.abs(counts - expected)) / expected < 0.2
+    assert abs(float(zf.mean()) - 0.5 * h) < 0.1 * h
 
 
 def test_single_step_matches_manual_ou():

--- a/tests/lagrangian/test_particles.py
+++ b/tests/lagrangian/test_particles.py
@@ -205,6 +205,25 @@ def test_well_mixed_condition_hanna():
     assert abs(float(zf.mean()) - 0.5 * h) < 0.1 * h
 
 
+def test_hanna_ground_level_drift_is_finite():
+    # The convective Hanna σ_w² carries a (z/h)^{2/3} factor whose ∂/∂z is
+    # singular at z = 0, so a ground-level particle (or one reflected exactly to
+    # the ground) would give inf/NaN vertical drift. HannaTurbulence.at floors z,
+    # so the langevin step must stay finite.
+    turb = HannaTurbulence(
+        u_star=0.5, pbl_height=1000.0, obukhov_length=-50.0, w_star=2.0
+    )
+    state = ParticleState(
+        position=jnp.array([[0.0, 0.0, 0.0]]),  # exactly at the ground
+        velocity=jnp.zeros((1, 3)),
+    )
+    nxt = langevin_step(
+        state, jnp.zeros(3), turb, 1.0, jax.random.PRNGKey(0), pbl_height=1000.0
+    )
+    assert np.all(np.isfinite(np.asarray(nxt.position)))
+    assert np.all(np.isfinite(np.asarray(nxt.velocity)))
+
+
 def test_single_step_matches_manual_ou():
     turb = HomogeneousTurbulence.isotropic(sigma=1.0, tau=10.0)
     state = ParticleState(


### PR DESCRIPTION
Implements epic #23 — the Lagrangian & assimilation correctness cluster — in a single PR.

## #48 — Footprint units convention
`compute_footprint` divided residence by `ρ·A_cell·mix_height`, giving **s·kg⁻¹** while the docstring, Returns section, and the FLEXPART/STILT literature it cites claim the **flux-sensitivity** convention s·m²·kg⁻¹.

- Drop the per-cell-area division, so `F` is the sensitivity to a surface **flux** `q` in kg·m⁻²·s⁻¹ (`y = Σ_s F·q`), matching the docstring and [stohl2005flexpart].
- Align the `inversion.py` module docstring on `q`'s flux units.
- Re-pin the residence invariant (`Σ F · ρ · mix_height = t_back`, no `A_cell`) and add `test_footprint_units_convention` (F ∝ 1/(ρ·f·h), independent of cell area).

## #49 — DFS mixes control spaces
`degrees_of_freedom_for_signal` combined an **ξ-space** (whitened) Hessian with a **model-space** `B⁻¹` solve — correct only at `B = I`, which both tests silently relied on.

- Add an explicit `whitened` mode. Model space (`whitened=False`) pairs `build_cost_x` + `background_op=B`; whitened (`whitened=True`) pairs `build_cost_xi`, whose prior is `B_ξ = I`, so `background_op` must be omitted (and is rejected if passed).
- `posterior_covariance_proxy` gains a `whitening` argument that recovers the model-space covariance `Bₐ = U Hess_ξ⁻¹ Uᵀ` from a whitened Hessian.
- `test_dfs_nonidentity_background`: model-space and whitened paths agree (and match an exact dense reference) for a strongly heteroscedastic `B ≠ I`, where the old mix gave a materially different number.

## #50 — HannaTurbulence adapter
`hanna_profiles` was a bare function with no `.at(z)`, so the integrator's inhomogeneous well-mixed drift path (`½(1+v_w²/σ_w²)∂σ_w²/∂z`) was unreachable with shipped code.

- Add `HannaTurbulence` — a frozen dataclass binding the surface-layer scales and exposing `at(z) -> (σ, τ)`; export it and fix the `particles.py` docstring reference.
- `test_well_mixed_condition_hanna`: an initially uniform slab stays uniform under convective (height-varying `σ_w`) turbulence.

## #51 — Backward footprint runs the wind on the forward clock
`back_wind(t) = −wind(t)` sampled a time-varying wind at pseudo-time `t`, not at the receptor's physical time.

- Add `receptor_time`; the backward step now samples `−wind(receptor_time − τ)`. Default `0.0` is exact for a stationary wind (its argument is ignored).
- `test_time_varying_wind_clock`: under an accelerating wind the corrected footprint retraces a forward-simulated trajectory, while the old forward-clock path does not.

## #52 — LagrangianDispersion.get_config
The hand-written config emitted a bogus `stability_class` key (a `GaussianPlume` copy-paste — not a constructor parameter) and dropped `pbl_height` / `background_conc` / `seed`.

- Return the real constructor surface; `test_lagrangian_dispersion_config_keys` asserts every key is a constructor parameter and the real fields round-trip.

## Testing
Targeted suites green: `tests/lagrangian/` + `tests/assimilation/` (92 passed). `ruff check .`, `ruff format --check .`, and `ty check src/plumax` clean (the one pre-existing `ty` warning in `lagrangian/inversion.py:57` is untouched).

Closes #48, #49, #50, #51, #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEgZbnU2EmmhBrogbmxa9N

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEgZbnU2EmmhBrogbmxa9N)_