### PR TITLE
fix(radtran/matched_filter/hapi_lut): retrieval-stack robustness (epic #22)

### DIFF
--- a/src/plumax/hapi_lut/generator.py
+++ b/src/plumax/hapi_lut/generator.py
@@ -11,6 +11,7 @@ plumax.hapi_lut`` does not require ``hitran-api`` to be installed.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from datetime import UTC, datetime
@@ -60,6 +61,38 @@ def _init_hapi_cache(cache_dir: Path) -> None:
     db_begin(str(cache_dir))
 
 
+def _range_sidecar_path(cache: Path, name: str) -> Path:
+    """Sidecar recording the wavenumber range currently backing ``<name>.data``."""
+    return cache / f"{name}.range.json"
+
+
+def _write_cached_range(cache: Path, name: str, nu_min: float, nu_max: float) -> None:
+    """Record the ν range a successful fetch wrote into the cache."""
+    _range_sidecar_path(cache, name).write_text(
+        json.dumps({"nu_min": float(nu_min), "nu_max": float(nu_max)})
+    )
+
+
+def _read_cached_range(cache: Path, name: str) -> tuple[float, float] | None:
+    """Return the cached ``(nu_min, nu_max)`` or ``None`` if unrecorded/unreadable."""
+    path = _range_sidecar_path(cache, name)
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+        return float(payload["nu_min"]), float(payload["nu_max"])
+    except (ValueError, KeyError, OSError):
+        return None
+
+
+def _range_covers(
+    cached: tuple[float, float], gas_config: GasConfig, *, tol: float = 1e-6
+) -> bool:
+    """True iff the cached range spans the requested ``[nu_min, nu_max]``."""
+    lo, hi = cached
+    return lo <= gas_config.nu_min + tol and hi + tol >= gas_config.nu_max
+
+
 def fetch_hitran_data(
     gas_config: GasConfig,
     cache_dir: Path | str | None = None,
@@ -67,14 +100,21 @@ def fetch_hitran_data(
     """Fetch HITRAN line parameters for ``gas_config`` into ``cache_dir``.
 
     HAPI writes a ``<GasConfig.name>.data`` + ``.header`` pair under
-    ``cache_dir``. If a cached pair already exists this call no-ops without
-    contacting HITRAN; otherwise the line parameters are downloaded and
-    parsed by HAPI.
+    ``cache_dir``, **overwriting** any existing pair (HAPI's ``fetch`` does not
+    no-op on a cache hit). A successful fetch also records the fetched ν range
+    in a ``<name>.range.json`` sidecar.
+
+    When ``fetch()`` fails (no network, API error) the previously-cached pair is
+    only reused if its recorded range **covers** the requested
+    ``[nu_min, nu_max]`` — otherwise a narrowed cache (e.g. left by
+    :func:`plumax.hapi_lut.multi.create_combined_lut`, which fetches over the
+    gas intersection range) would silently serve a truncated line list, and
+    ``absorptionCoefficient_Voigt`` would return σ ≈ 0 outside it.
 
     Raises:
-        RuntimeError: if ``fetch()`` raises (e.g. no network, invalid range)
-            *and* no cached pair is already present. The underlying HAPI
-            exception is chained so the network / API error is visible.
+        RuntimeError: if ``fetch()`` raises and either no cached pair is present
+            or its recorded range does not cover the request. The underlying
+            HAPI exception is chained so the network / API error is visible.
 
     Returns:
         The resolved cache directory.
@@ -95,9 +135,10 @@ def fetch_hitran_data(
         gas_config.isotopologue_id,
         gas_config.nu_min,
         gas_config.nu_max,
-        " [cache hit]" if already_cached else "",
+        " [cache present]" if already_cached else "",
     )
 
+    fetched = True
     try:
         fetch(
             gas_config.name,
@@ -107,26 +148,51 @@ def fetch_hitran_data(
             gas_config.nu_max,
         )
     except Exception as exc:
-        # HAPI raises plain Exceptions on network failures and API errors.
-        # If we have a cached pair we can proceed — otherwise the user sees
-        # a clear failure instead of silently-corrupt LUTs downstream.
-        if not already_cached:
+        # HAPI raises plain Exceptions on network failures and API errors. A
+        # cached pair is only trustworthy if its recorded range covers the
+        # request — otherwise proceeding would feed a truncated line list to
+        # the Voigt sum and silently produce σ ≈ 0 outside the cached window.
+        fetched = False
+        cached_range = _read_cached_range(cache, gas_config.name)
+        if (
+            not already_cached
+            or cached_range is None
+            or not _range_covers(cached_range, gas_config)
+        ):
+            detail = (
+                "no cached data was found"
+                if not already_cached
+                else (
+                    "the cached line list has no recorded range"
+                    if cached_range is None
+                    else f"the cached line list covers only "
+                    f"{cached_range[0]:.1f}-{cached_range[1]:.1f} cm^-1"
+                )
+            )
             raise RuntimeError(
                 f"HITRAN fetch failed for {gas_config.name} "
                 f"(M{gas_config.molecule_id} I{gas_config.isotopologue_id}, "
-                f"{gas_config.nu_min:.1f}-{gas_config.nu_max:.1f} cm^-1) "
-                f"and no cached data was found at {cache}."
+                f"{gas_config.nu_min:.1f}-{gas_config.nu_max:.1f} cm^-1) and "
+                f"{detail} at {cache}. Re-fetch online or point `cache_dir` at "
+                "a cache whose range spans the request."
             ) from exc
         logger.warning(
-            "fetch() raised %s — proceeding with cached %s.",
+            "fetch() raised %s — proceeding with cached %s (range %.1f-%.1f "
+            "cm^-1 covers the request).",
             type(exc).__name__,
             data_path,
+            cached_range[0],
+            cached_range[1],
         )
 
     if not (data_path.exists() and header_path.exists()):
         raise RuntimeError(
             f"HITRAN fetch for {gas_config.name} returned without error but "
             f"no {gas_config.name}.data/.header pair was produced under {cache}."
+        )
+    if fetched:
+        _write_cached_range(
+            cache, gas_config.name, gas_config.nu_min, gas_config.nu_max
         )
     return cache
 

--- a/src/plumax/matched_filter/background.py
+++ b/src/plumax/matched_filter/background.py
@@ -128,15 +128,19 @@ def estimate_cov_empirical(
     mean: np.ndarray | None = None,
     *,
     ridge: float = 0.0,
+    mask: np.ndarray | None = None,
 ) -> LinearOperator:
     """Empirical covariance via :class:`sklearn.covariance.EmpiricalCovariance`.
 
     Returns a dense :class:`lineax.MatrixLinearOperator`. Optionally adds a
     diagonal ``ridge`` for numerical PD-ness when ``n_samples ≲ n_bands``.
+    ``mask`` (boolean exclude-pixels) drops flagged pixels — e.g. a detected
+    plume — so ``Σ`` is estimated from background only, consistent with a robust
+    masked ``μ``.
     """
     from sklearn.covariance import EmpiricalCovariance
 
-    X = _flatten_cube(cube)
+    X = _flatten_cube_masked(cube, mask)
     est = EmpiricalCovariance(store_precision=False).fit(X)
     cov = est.covariance_
     if mean is not None:
@@ -154,14 +158,16 @@ def estimate_cov_shrunk(
     mean: np.ndarray | None = None,
     *,
     method: Literal["ledoit_wolf", "oas"] = "ledoit_wolf",
+    mask: np.ndarray | None = None,
 ) -> LinearOperator:
     """Shrinkage covariance estimator.
 
     Uses Ledoit–Wolf (``method='ledoit_wolf'``, default) or OAS
     (``'oas'``) — both shrink the sample covariance toward a scaled identity
-    and are PD by construction even when ``n_samples < n_bands``.
+    and are PD by construction even when ``n_samples < n_bands``. ``mask``
+    (boolean exclude-pixels) drops flagged pixels before fitting.
     """
-    X = _flatten_cube(cube)
+    X = _flatten_cube_masked(cube, mask)
     if mean is not None:
         X = X - mean
         assume_centered = True
@@ -193,6 +199,8 @@ def estimate_cov_lowrank(
     tikhonov: float,
     random_state: int | None = 0,
     n_oversamples: int = 10,
+    mask: np.ndarray | None = None,
+    rank_rtol: float = 1e-10,
 ) -> LinearOperator:
     """Low-rank + Tikhonov covariance: ``Σ = λI + V D Vᵀ``.
 
@@ -220,10 +228,19 @@ def estimate_cov_lowrank(
     n_oversamples
         Extra random directions for the Halko sampling — higher is slower but
         better-conditioned. sklearn's default is 10.
+    mask
+        Boolean exclude-pixels mask; flagged pixels (e.g. a detected plume) are
+        dropped before the SVD so ``Σ`` reflects background only.
+    rank_rtol
+        Components whose covariance eigenvalue ``d_i`` is below
+        ``rank_rtol · max(d)`` are dropped before building the operator. On a
+        rank-deficient scene (constant regions, duplicated spectra) those
+        ``d_i ≈ 0`` would make gaussx's Woodbury capacitance ``diag(1/d) +
+        VᵀL⁻¹U`` blow up to inf/NaN; dropping them keeps every score finite.
     """
     if tikhonov <= 0.0:
         raise ValueError("estimate_cov_lowrank: tikhonov must be > 0.")
-    X = _flatten_cube(cube)
+    X = _flatten_cube_masked(cube, mask)
     mu = X.mean(axis=0) if mean is None else np.asarray(mean)
     Xc = X - mu
     n_samples, n_bands = Xc.shape
@@ -246,10 +263,18 @@ def estimate_cov_lowrank(
     V = svd.components_  # shape (rank, n_bands), rows are right singular vectors
     s = svd.singular_values_  # shape (rank,)
     d = (s**2) / max(n_samples, 1)
-    U = jnp.asarray(V.T)  # (n_bands, rank) — spectral directions as columns
     base = lx.DiagonalLinearOperator(
         jnp.asarray(tikhonov * np.ones(n_bands, dtype=float))
     )
+    # Rank-deficiency guard: drop near-zero eigen-directions so the Woodbury
+    # capacitance stays finite. If none survive (e.g. a constant scene), Σ is
+    # just the strictly-PD Tikhonov floor λI.
+    d_max = float(d.max()) if d.size else 0.0
+    keep = d > rank_rtol * d_max if d_max > 0.0 else np.zeros(d.shape, dtype=bool)
+    V, d = V[keep], d[keep]
+    if d.size == 0:
+        return base
+    U = jnp.asarray(V.T)  # (n_bands, n_kept) — spectral directions as columns
     return gx.LowRankUpdate(
         base,
         U,
@@ -268,3 +293,32 @@ def _flatten_cube(cube: Float[Array, "H W B"] | np.ndarray) -> np.ndarray:
             f"background estimator: cube must be (H, W, n_bands), got shape {arr.shape}."
         )
     return arr.reshape(-1, arr.shape[-1])
+
+
+def _flatten_cube_masked(
+    cube: Float[Array, "H W B"] | np.ndarray,
+    mask: np.ndarray | None,
+) -> np.ndarray:
+    """Flatten a cube to ``(n_kept, n_bands)``, dropping masked-out pixels.
+
+    ``mask`` is a boolean **exclude** mask — ``True`` marks pixels (e.g.
+    detected plume / target) to leave out of the background statistics so the
+    filter is not attenuated by its own signal. Any shape with one entry per
+    pixel is accepted (``(H, W)`` or flat).
+    """
+    X = _flatten_cube(cube)
+    if mask is None:
+        return X
+    m = np.asarray(mask, dtype=bool).reshape(-1)
+    if m.shape[0] != X.shape[0]:
+        raise ValueError(
+            f"background estimator: `mask` must have one entry per pixel "
+            f"({X.shape[0]}), got {m.size}."
+        )
+    kept = X[~m]
+    if kept.shape[0] < 2:
+        raise ValueError(
+            "background estimator: `mask` excludes all but "
+            f"{kept.shape[0]} pixel(s); need ≥ 2 for a covariance estimate."
+        )
+    return kept

--- a/src/plumax/matched_filter/cluster.py
+++ b/src/plumax/matched_filter/cluster.py
@@ -161,6 +161,7 @@ def adaptive_window_background(
     cube: np.ndarray,
     *,
     window_size: int,
+    guard_size: int = 0,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Per-pixel local mean and per-band variance over a square window.
 
@@ -177,6 +178,12 @@ def adaptive_window_background(
         Hyperspectral cube, shape ``(H, W, n_bands)``.
     window_size
         Edge length of the averaging window. Must be odd and ``>= 3``.
+    guard_size
+        Edge length of a central **guard region** excluded from each pixel's
+        window (a guard annulus). Must be odd and ``0 <= guard_size <
+        window_size``. The default ``0`` includes the centre pixel — but then a
+        plume pixel contaminates its *own* local background; ``guard_size=1``
+        excludes just the centre pixel, larger values exclude a bigger core.
 
     Returns
     -------
@@ -189,6 +196,15 @@ def adaptive_window_background(
         raise ValueError(
             f"adaptive_window_background: window_size must be an odd int ≥ 3; got {window_size}."
         )
+    if guard_size < 0 or (guard_size > 0 and guard_size % 2 == 0):
+        raise ValueError(
+            f"adaptive_window_background: guard_size must be 0 or an odd int; got {guard_size}."
+        )
+    if guard_size >= window_size:
+        raise ValueError(
+            f"adaptive_window_background: guard_size ({guard_size}) must be < "
+            f"window_size ({window_size})."
+        )
     arr = np.asarray(cube, dtype=float)
     if arr.ndim != 3:
         raise ValueError(
@@ -196,14 +212,28 @@ def adaptive_window_background(
         )
     from scipy.ndimage import uniform_filter
 
+    # Annulus counts: outer window minus the excluded central guard region.
+    n_out = window_size**2
+    n_in = guard_size**2 if guard_size > 0 else 0
+    n_ann = n_out - n_in
+
+    def window_mean(plane: np.ndarray) -> np.ndarray:
+        # Uniform (box) mean over the window, excluding the central guard region
+        # when guard_size > 0: annulus_sum / annulus_count via box-sum difference.
+        out_sum = uniform_filter(plane, size=window_size, mode="reflect") * n_out
+        if guard_size > 0:
+            in_sum = uniform_filter(plane, size=guard_size, mode="reflect") * n_in
+            return (out_sum - in_sum) / n_ann
+        return out_sum / n_out
+
     # Apply a 2-D moving average independently to each band — scipy handles
     # the reflect-boundary by default, matching how most MF codes handle
     # scene edges.
     mean = np.empty_like(arr)
     var = np.empty_like(arr)
     for b in range(arr.shape[-1]):
-        m = uniform_filter(arr[..., b], size=window_size, mode="reflect")
-        m2 = uniform_filter(arr[..., b] ** 2, size=window_size, mode="reflect")
+        m = window_mean(arr[..., b])
+        m2 = window_mean(arr[..., b] ** 2)
         mean[..., b] = m
         # Population variance — E[x²] - E[x]². Clipped to zero for numerics.
         var[..., b] = np.maximum(m2 - m * m, 0.0)

--- a/src/plumax/radtran/background.py
+++ b/src/plumax/radtran/background.py
@@ -39,6 +39,26 @@ def _flatten_pixels(
     return bands_first.reshape(n_bands, -1).T  # (n_pixels, n_bands)
 
 
+def _noise_matched_floor(
+    singular_values: np.ndarray, rank: int, n_samples: int
+) -> float:
+    """Diagonal floor ``λ`` = mean of the *discarded* covariance eigenvalues.
+
+    The retained rank captures the signal subspace; the remaining singular
+    directions carry the sensor noise, with covariance eigenvalues
+    ``S[rank:]² / N``. Setting ``λ`` to their mean makes ``Σ⁻¹`` weight the
+    discarded subspace at the true noise level (SNR-optimal) rather than at an
+    arbitrary fixed floor. Falls back to a small positive value when no modes
+    are discarded (rank-complete) or the estimate is degenerate.
+    """
+    discarded = np.asarray(singular_values, dtype=float)[rank:]
+    if discarded.size > 0:
+        lam = float(np.mean(discarded**2) / max(n_samples, 1))
+        if lam > 0.0:
+            return lam
+    return 1e-6
+
+
 def trimmed_mean_spectrum(
     radiance: np.ndarray,
     *,
@@ -76,7 +96,7 @@ def robust_lowrank_covariance(
     *,
     rank: int | None = None,
     trim_frac: float = 0.1,
-    regularization: float = 1e-6,
+    regularization: float | None = None,
     band_axis: int = 0,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Robust low-rank covariance + inverse ``(Σ, Σ⁻¹)``.
@@ -102,8 +122,13 @@ def robust_lowrank_covariance(
         variance is in a handful of modes.
     trim_frac : float
         Per-pixel energy-based trim fraction in ``[0, 0.5)``. Default 0.1.
-    regularization : float
-        Diagonal Tikhonov term ``λ``. Default ``1e-6``.
+    regularization : float or None
+        Diagonal Tikhonov floor ``λ`` on the discarded subspace. ``None``
+        (default) uses the **noise-matched** floor — the mean of the discarded
+        covariance eigenvalues ``mean(S[rank:]²)/N`` — so ``Σ⁻¹`` weights that
+        subspace at the real sensor-noise level instead of an arbitrary
+        constant. A floor too small over-weights the noise subspace (inflating
+        false alarms); too large leaks signal into it. Pass a float to override.
     band_axis : int
         Band axis of ``radiance``. Default 0.
 
@@ -120,7 +145,7 @@ def robust_lowrank_covariance(
         raise ValueError(
             f"robust_lowrank_covariance: `trim_frac` must be in [0, 0.5) (got {trim_frac!r})"
         )
-    if regularization <= 0.0:
+    if regularization is not None and regularization <= 0.0:
         raise ValueError("robust_lowrank_covariance: `regularization` must be > 0.")
     if rank is None:
         rank = min(n_bands - 1, 16)
@@ -151,9 +176,10 @@ def robust_lowrank_covariance(
     S_k = S[:rank]
     V_k = Vt[:rank]  # shape (rank, n_bands); V_k.T are the principal directions.
 
-    # Σ in the top-k subspace (1 / N) · Vᵀ S² V.
+    # Σ in the top-k subspace (1 / N) · Vᵀ S² V, plus the diagonal floor λ.
     N = centred.shape[0]
-    Sigma = (V_k.T * (S_k**2)) @ V_k / max(N, 1) + regularization * np.eye(n_bands)
+    lam = _noise_matched_floor(S, rank, N) if regularization is None else regularization
+    Sigma = (V_k.T * (S_k**2)) @ V_k / max(N, 1) + lam * np.eye(n_bands)
 
     # Woodbury inverse for efficiency: (λI + Uᵀ D U)⁻¹ where
     #   U = V_k (rank, n_bands), D = diag(S_k² / N) (rank, rank).

--- a/src/plumax/radtran/forward.py
+++ b/src/plumax/radtran/forward.py
@@ -79,6 +79,19 @@ def _interp_sigma(
             f"forward model: variable {var!r} not in dataset "
             f"(have {list(ds.data_vars)})"
         )
+    # Bounds-check (T, P) against the LUT grid before interpolating: xarray's
+    # linear interp returns all-NaN outside the grid, which surfaces downstream
+    # as a misleading "Σ is not PD" error. Fail here, naming the offending value.
+    for name, value in (("T_K", T_K), ("p_atm", p_atm)):
+        coord = "temperature" if name == "T_K" else "pressure"
+        if coord in ds.coords:
+            lo, hi = float(ds[coord].min()), float(ds[coord].max())
+            if not (lo <= float(value) <= hi):
+                raise ValueError(
+                    f"forward model: `{name}` ({value!r}) is outside the LUT "
+                    f"`{coord}` grid range [{lo}, {hi}]; extend the LUT or clamp "
+                    "the query."
+                )
     nu_da = xr.DataArray(np.asarray(nu_obs, dtype=float), dims=["obs_nu"])
     sigma = ds[var].interp(
         wavenumber=nu_da, temperature=T_K, pressure=p_atm, method="linear"

--- a/src/plumax/radtran/gaussx_solve.py
+++ b/src/plumax/radtran/gaussx_solve.py
@@ -26,6 +26,15 @@ inversion-free on the hot path:
 
 The functions accept NumPy inputs and return NumPy outputs — the gaussx
 internals run on JAX arrays for us, but callers don't need to know.
+
+.. important::
+   This path requires **64-bit JAX** (``jax_enable_x64``). With x64 disabled
+   (JAX's default) the float64 SVD factors are silently truncated to float32
+   and the ill-conditioned Woodbury capacitance solve loses precision (up to
+   ~1e-5 relative, worse for hyperspectral ``B ≳ 200``). Rather than return a
+   quietly-wrong result, every entry point raises a clear error when x64 is off
+   — enable it once at import time:
+   ``import jax; jax.config.update("jax_enable_x64", True)``.
 """
 
 from __future__ import annotations
@@ -59,19 +68,35 @@ _GAUSSX_INSTALL_HINT = (
 )
 
 
+_X64_REQUIRED_HINT = (
+    "plumax.radtran.gaussx_solve requires 64-bit JAX for its low-rank "
+    "covariance path. With `jax_enable_x64` disabled (JAX's default) the "
+    "float64 SVD factors are silently truncated to float32 and the "
+    "ill-conditioned Woodbury capacitance solve loses precision, so the result "
+    "would be quietly wrong. Enable x64 once, before building any arrays:\n"
+    "    import jax; jax.config.update('jax_enable_x64', True)"
+)
+
+
 def _import_gaussx_stack():
     """Import ``gaussx`` + the ``jax``/``lineax`` pieces this module needs.
 
     Wrapping the imports here lets us turn any ``ModuleNotFoundError`` into
     one actionable message instead of three different stack traces depending
-    on which dependency is missing.
+    on which dependency is missing. It also enforces the 64-bit-JAX
+    requirement (see the module docstring): the low-rank covariance path is
+    silently degraded to float32 without it, so we raise rather than return a
+    quietly-wrong result.
     """
     try:
         import gaussx as gx
+        import jax
         import jax.numpy as jnp
         import lineax as lx
     except ModuleNotFoundError as exc:  # pragma: no cover — install-time path
         raise ModuleNotFoundError(_GAUSSX_INSTALL_HINT) from exc
+    if not jax.config.jax_enable_x64:
+        raise RuntimeError(_X64_REQUIRED_HINT)
     return gx, jnp, lx
 
 
@@ -83,7 +108,7 @@ def build_lowrank_covariance_operator(
     *,
     rank: int | None = None,
     trim_frac: float = 0.1,
-    regularization: float = 1e-6,
+    regularization: float | None = None,
     band_axis: int = 0,
 ) -> tuple[LowRankUpdateOp, np.ndarray]:
     """Build a :class:`gaussx.LowRankUpdate` covariance operator from a scene.
@@ -112,6 +137,7 @@ def build_lowrank_covariance_operator(
 
     from plumax.radtran.background import (
         _flatten_pixels,
+        _noise_matched_floor,
         trimmed_mean_spectrum,
     )
 
@@ -126,7 +152,7 @@ def build_lowrank_covariance_operator(
             f"build_lowrank_covariance_operator: `trim_frac` must be in "
             f"[0, 0.5) (got {trim_frac!r})"
         )
-    if regularization <= 0.0:
+    if regularization is not None and regularization <= 0.0:
         raise ValueError(
             "build_lowrank_covariance_operator: `regularization` must be > 0."
         )
@@ -151,18 +177,25 @@ def build_lowrank_covariance_operator(
     _, S, Vt = np.linalg.svd(centred, full_matrices=False)
     S_k = S[:rank]
     V_k = Vt[:rank]  # (rank, n_bands)
+    n_kept = centred.shape[0]
 
     # U: principal directions as columns.
     U = jnp.asarray(V_k.T)  # (n_bands, rank)
-    d = jnp.asarray(S_k**2 / max(centred.shape[0], 1))  # diag of U d Uᵀ
-    # Base: regularisation · I as an explicit *diagonal* operator so
-    # gaussx.solve picks up the fast per-element inverse path. A naive
-    # ``regularization * IdentityLinearOperator(...)`` would build a
-    # ScaledOperator that gaussx does not specialise and that would
-    # compute the dense inverse instead.
-    base = lx.DiagonalLinearOperator(
-        regularization * jnp.ones(n_bands, dtype=jnp.float64)
+    d = jnp.asarray(S_k**2 / max(n_kept, 1))  # diag of U d Uᵀ
+    # Diagonal floor λ: noise-matched by default (mean of the discarded
+    # covariance eigenvalues) so Σ⁻¹ weights the discarded subspace at the true
+    # sensor-noise level; see background._noise_matched_floor. Kept identical to
+    # the dense `robust_lowrank_covariance` path so the two agree.
+    lam = (
+        _noise_matched_floor(S, rank, n_kept)
+        if regularization is None
+        else float(regularization)
     )
+    # Base: λ · I as an explicit *diagonal* operator so gaussx.solve picks up the
+    # fast per-element inverse path. A naive ``λ * IdentityLinearOperator(...)``
+    # would build a ScaledOperator that gaussx does not specialise and that would
+    # compute the dense inverse instead.
+    base = lx.DiagonalLinearOperator(lam * jnp.ones(n_bands, dtype=jnp.float64))
 
     cov = gx.LowRankUpdate(
         base,

--- a/src/plumax/radtran/instrument.py
+++ b/src/plumax/radtran/instrument.py
@@ -39,6 +39,11 @@ from jaxtyping import Array, Float
 
 
 PSFType = Literal["gaussian", "airy"]
+
+# Argument at which the Airy intensity ``(2·J₁(x)/x)²`` reaches half its peak.
+# Placing this at ``r = fwhm_pixels / 2`` makes the kernel's measured FWHM equal
+# ``fwhm_pixels`` — matching the Gaussian PSF's exact FWHM semantics.
+_AIRY_HALF_MAX_X: float = 1.6163399
 HRCube = Float[Array, "ny nx n_lambda"]
 LRCube = Float[Array, "ny_lr nx_lr n_lambda"]
 
@@ -120,7 +125,14 @@ class PointSpreadFunction:
 
     @classmethod
     def airy(cls, fwhm_pixels: float, kernel_size: int = 9) -> PointSpreadFunction:
-        """Build an Airy-disk-like PSF as a diffraction-ish surrogate."""
+        """Build an Airy-disk-like PSF as a diffraction-ish surrogate.
+
+        ``fwhm_pixels`` is the kernel's full width at half maximum, matching
+        :meth:`gaussian`. The Airy argument is scaled so the half-max radius
+        (``x = _AIRY_HALF_MAX_X``) falls at ``r = fwhm_pixels / 2``; the earlier
+        ``1.22·fwhm`` (first-zero) scaling produced a kernel ≈ 0.63× the
+        requested FWHM.
+        """
         from scipy.special import j1
 
         if fwhm_pixels <= 0.0:
@@ -128,7 +140,7 @@ class PointSpreadFunction:
         c = kernel_size // 2
         y, x = np.ogrid[-c : c + 1, -c : c + 1]
         r = np.sqrt(x * x + y * y)
-        xarg = np.where(r == 0.0, 1e-12, 2.0 * np.pi * r / (1.22 * fwhm_pixels))
+        xarg = np.where(r == 0.0, 1e-12, 2.0 * _AIRY_HALF_MAX_X * r / fwhm_pixels)
         k = (2.0 * j1(xarg) / xarg) ** 2
         return cls(kernel=k)
 

--- a/src/plumax/radtran/nb_lut.py
+++ b/src/plumax/radtran/nb_lut.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 import numpy as np
 import xarray as xr
 
-from plumax.radtran.srf import SpectralResponseFunction
+from plumax.radtran.srf import SpectralResponseFunction, check_srf_lut_coverage
 
 
 @dataclass(frozen=True)
@@ -149,6 +149,9 @@ def build_nb_lut(
     # for np.interp after flipping).
     lam_src = sigma_lambda["lam_nm"].values
     sort = np.argsort(lam_src)
+    # Flag bands whose SRF response reaches past the LUT wavelength coverage;
+    # np.interp zero-fills σ there, producing a silently-attenuated nB (≡ 1).
+    check_srf_lut_coverage(srf, lam_src, context="build_nb_lut")
     sigma_hr = np.interp(
         srf.wavelengths_hr_nm,
         lam_src[sort],

--- a/src/plumax/radtran/srf.py
+++ b/src/plumax/radtran/srf.py
@@ -31,6 +31,7 @@ Plus ``'custom'`` which accepts an arbitrary ``(n_bands, n_λ)`` matrix
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -243,3 +244,54 @@ class SpectralResponseFunction:
                 f"must equal n_bands={self.n_bands}"
             )
         return np.einsum("bl, ...b -> ...l", self.matrix, u)
+
+
+def check_srf_lut_coverage(
+    srf: SpectralResponseFunction,
+    lut_wavelengths_nm: np.ndarray,
+    *,
+    context: str,
+    tol: float = 1e-2,
+) -> np.ndarray:
+    """Warn when SRF bands respond outside the LUT's wavelength coverage.
+
+    Resampling a cross-section / target spectrum onto the SRF grid zero-fills
+    wavelengths beyond the LUT range (``np.interp(..., left=0, right=0)``),
+    silently attenuating any band whose response reaches there — a band whose
+    support lies wholly outside gets an exactly-zero (and misleading) value.
+    This computes each band's fraction of SRF mass *outside* the LUT coverage
+    and warns for bands exceeding ``tol``.
+
+    Parameters
+    ----------
+    srf
+        Instrument SRF.
+    lut_wavelengths_nm
+        Wavelengths [nm] covered by the LUT (any order); coverage is taken as
+        ``[min, max]``.
+    context
+        Caller name, prepended to the warning message.
+    tol
+        Out-of-coverage SRF-mass fraction above which a band is flagged.
+
+    Returns
+    -------
+    frac_out : np.ndarray
+        Per-band fraction of SRF response outside the LUT coverage.
+    """
+    lam = np.asarray(lut_wavelengths_nm, dtype=float)
+    lam_min, lam_max = float(lam.min()), float(lam.max())
+    hr = srf.wavelengths_hr_nm
+    in_range = (hr >= lam_min) & (hr <= lam_max)
+    total = srf.matrix.sum(axis=1)
+    covered = srf.matrix[:, in_range].sum(axis=1)
+    frac_out = np.where(total > 0.0, 1.0 - covered / total, 0.0)
+    for b in np.nonzero(frac_out > tol)[0]:
+        warnings.warn(
+            f"{context}: band {srf.band_names[b]!r} has {frac_out[b] * 100:.1f}% "
+            f"of its SRF response outside the LUT wavelength coverage "
+            f"[{lam_min:.1f}, {lam_max:.1f}] nm; its band-integrated value is "
+            "silently zero-filled there.",
+            stacklevel=3,
+        )
+    return frac_out

--- a/src/plumax/radtran/target.py
+++ b/src/plumax/radtran/target.py
@@ -33,7 +33,7 @@ from plumax.radtran.forward import (
     forward_maclaurin_normalized,
     forward_nonlinear_normalized,
 )
-from plumax.radtran.srf import SpectralResponseFunction
+from plumax.radtran.srf import SpectralResponseFunction, check_srf_lut_coverage
 
 
 def target_spectrum_normalized_nonlinear(
@@ -135,5 +135,8 @@ def target_bands(
     sort_idx = np.argsort(wavelengths_nm)
     lam = np.asarray(wavelengths_nm)[sort_idx]
     t = np.asarray(target_hr)[sort_idx]
+    # Flag bands whose SRF response reaches past the LUT wavelength coverage;
+    # np.interp zero-fills there and would silently attenuate the target.
+    check_srf_lut_coverage(srf, lam, context="target_bands")
     t_on_srf_grid = np.interp(srf.wavelengths_hr_nm, lam, t, left=0.0, right=0.0)
     return srf.apply(t_on_srf_grid)

--- a/tests/hapi_lut/test_generator.py
+++ b/tests/hapi_lut/test_generator.py
@@ -15,6 +15,7 @@ unless that pair actually exists on disk.
 
 from __future__ import annotations
 
+import json
 import sys
 import types
 from pathlib import Path
@@ -152,9 +153,11 @@ def test_fetch_hitran_data_raises_when_fetch_fails_and_no_cache(monkeypatch, tmp
 def test_fetch_hitran_data_tolerates_fetch_failure_if_cache_present(
     monkeypatch, tmp_path
 ):
-    # Pre-populate the cache and then make fetch() raise — should not abort.
+    # Pre-populate the cache with a range sidecar that COVERS the request, then
+    # make fetch() raise — the offline fallback should proceed.
     (tmp_path / "CH4.data").write_text("stub\n")
     (tmp_path / "CH4.header").write_text("stub\n")
+    (tmp_path / "CH4.range.json").write_text('{"nu_min": 4000.0, "nu_max": 4001.0}')
     fake = _make_hapi_stub(fetch_raises=RuntimeError)
     monkeypatch.setitem(sys.modules, "hapi", fake)
     gas = GasConfig(
@@ -162,6 +165,46 @@ def test_fetch_hitran_data_tolerates_fetch_failure_if_cache_present(
     )
     out = fetch_hitran_data(gas, cache_dir=tmp_path)
     assert out == tmp_path
+
+
+def test_fetch_writes_range_sidecar(stub_hapi, tmp_path):
+    # A successful fetch records the fetched ν range for later coverage checks.
+    gas = GasConfig(
+        "CH4", molecule_id=6, isotopologue_id=1, nu_min=4000.0, nu_max=4500.0
+    )
+    fetch_hitran_data(gas, cache_dir=tmp_path)
+    payload = json.loads((tmp_path / "CH4.range.json").read_text())
+    assert payload == {"nu_min": 4000.0, "nu_max": 4500.0}
+
+
+def test_cache_range_mismatch_rejected(monkeypatch, tmp_path):
+    # A narrowed cache (e.g. from a combined-LUT intersection fetch) plus an
+    # offline failure for a WIDER request must raise rather than silently serve
+    # a truncated line list.
+    (tmp_path / "CH4.data").write_text("stub\n")
+    (tmp_path / "CH4.header").write_text("stub\n")
+    (tmp_path / "CH4.range.json").write_text('{"nu_min": 4000.0, "nu_max": 4500.0}')
+    fake = _make_hapi_stub(fetch_raises=RuntimeError)
+    monkeypatch.setitem(sys.modules, "hapi", fake)
+    gas = GasConfig(
+        "CH4", molecule_id=6, isotopologue_id=1, nu_min=4000.0, nu_max=8000.0
+    )
+    with pytest.raises(RuntimeError, match=r"covers only 4000\.0-4500\.0"):
+        fetch_hitran_data(gas, cache_dir=tmp_path)
+
+
+def test_fetch_failure_without_range_sidecar_rejected(monkeypatch, tmp_path):
+    # A legacy cache with no recorded range can't be verified — reject on the
+    # offline fallback rather than trust an unknown coverage.
+    (tmp_path / "CH4.data").write_text("stub\n")
+    (tmp_path / "CH4.header").write_text("stub\n")
+    fake = _make_hapi_stub(fetch_raises=RuntimeError)
+    monkeypatch.setitem(sys.modules, "hapi", fake)
+    gas = GasConfig(
+        "CH4", molecule_id=6, isotopologue_id=1, nu_min=4000.0, nu_max=4001.0
+    )
+    with pytest.raises(RuntimeError, match="no recorded range"):
+        fetch_hitran_data(gas, cache_dir=tmp_path)
 
 
 def test_compute_absorption_lut_raises_when_voigt_call_fails(monkeypatch, tmp_path):

--- a/tests/matched_filter/test_background.py
+++ b/tests/matched_filter/test_background.py
@@ -117,3 +117,50 @@ def test_lowrank_covariance_is_symmetric(rng):
     cov_op = estimate_cov_lowrank(cube, rank=3, tikhonov=1e-3)
     M = np.asarray(cov_op.as_matrix())
     np.testing.assert_allclose(M, M.T, atol=1e-12)
+
+
+def test_masked_cov_excludes_plume(rng):
+    # A bright plume block inflates the unmasked covariance; masking those
+    # pixels must recover the background-only covariance (identical to the
+    # clean scene with the same pixels excluded).
+    B = 8
+    clean = 1.0 + rng.standard_normal((20, 20, B)) * 0.05
+    cube = clean.copy()
+    plume = np.zeros((20, 20), dtype=bool)
+    plume[:4, :4] = True
+    cube[plume] += 5.0  # strong contaminant only on the plume pixels
+
+    cov_all = np.asarray(estimate_cov_empirical(cube).as_matrix())
+    cov_masked = np.asarray(estimate_cov_empirical(cube, mask=plume).as_matrix())
+    # Reference: clean scene with the same pixels excluded (non-plume pixels of
+    # `cube` and `clean` are identical), so the masked estimate must match it.
+    cov_ref = np.asarray(estimate_cov_empirical(clean, mask=plume).as_matrix())
+
+    np.testing.assert_allclose(cov_masked, cov_ref, atol=1e-10)
+    assert np.trace(cov_all) > 5.0 * np.trace(cov_masked)
+
+
+def test_masked_cov_rejects_wrong_shape(rng):
+    cube = _noisy_cube(rng, H=10, W=10, B=4)
+    with pytest.raises(ValueError, match="one entry per pixel"):
+        estimate_cov_empirical(cube, mask=np.zeros(7, dtype=bool))
+
+
+def test_rank_deficient_scene_finite(rng):
+    # A rank-2 scene (all spectra are combinations of two) has covariance rank 2,
+    # so a rank-8 request yields near-zero eigen-directions. Without the
+    # rank-deficiency guard the Woodbury capacitance diag(1/d) blows up to
+    # inf/NaN; with it, the solve stays finite and matches the dense form.
+    import gaussx as gx
+
+    B = 10
+    basis = rng.standard_normal((2, B))
+    X = rng.standard_normal((400, 2)) @ basis  # exactly rank 2
+    cube = X.reshape(400, 1, B)
+    cov_op = estimate_cov_lowrank(cube, rank=8, tikhonov=1e-4)
+
+    rhs = jnp.asarray(rng.standard_normal(B))
+    x = np.asarray(gx.solve(cov_op, rhs))
+    assert np.all(np.isfinite(x))
+    dense = np.asarray(cov_op.as_matrix())
+    np.testing.assert_allclose(x, np.linalg.solve(dense, np.asarray(rhs)), atol=1e-6)

--- a/tests/matched_filter/test_cluster.py
+++ b/tests/matched_filter/test_cluster.py
@@ -53,6 +53,23 @@ def test_adaptive_window_rejects_even_window(rng):
         adaptive_window_background(cube, window_size=4)
 
 
+def test_adaptive_window_guard_annulus_excludes_centre(rng):
+    # guard_size=1 drops the centre pixel from each window, so a plume pixel
+    # can't contaminate its own local background. Interior annulus mean = window
+    # mean with the centre removed.
+    cube = rng.standard_normal((9, 9, 1)) * 0.5 + 1.0
+    mean, _ = adaptive_window_background(cube, window_size=3, guard_size=1)
+    patch = cube[3:6, 3:6, 0]
+    expected = (patch.sum() - patch[1, 1]) / (patch.size - 1)
+    np.testing.assert_allclose(mean[4, 4, 0], expected, atol=1e-12)
+
+
+def test_adaptive_window_rejects_guard_ge_window(rng):
+    cube = rng.standard_normal((7, 7, 2))
+    with pytest.raises(ValueError, match="guard_size"):
+        adaptive_window_background(cube, window_size=3, guard_size=3)
+
+
 def test_gmm_small_cluster_fallback_is_consistent(rng):
     """When a cluster has < 2 pixels the ``(μ_k, Σ_k)`` pair must be
     self-consistent — both coming from the global scene statistics. Regression

--- a/tests/radtran/test_background.py
+++ b/tests/radtran/test_background.py
@@ -77,3 +77,38 @@ def test_default_rank_is_reasonable():
     Sigma, _ = robust_lowrank_covariance(scene)  # rank=None → min(n_bands-1, 16)
     # Should still produce a full-rank Σ after the Tikhonov kick.
     assert np.linalg.matrix_rank(Sigma) == 10
+
+
+def test_noise_matched_floor_far():
+    # A low-rank background plus iid sensor noise. Retaining the signal rank and
+    # flooring the discarded subspace at the *noise* level (default None) should
+    # weight noise directions correctly, giving a tighter false-alarm
+    # distribution than the fixed λ=1e-6 floor, which over-weights that subspace.
+    rng = np.random.default_rng(0)
+    n_bands, k_true, noise_sigma = 60, 5, 0.01
+    modes = rng.standard_normal((k_true, n_bands))
+    scale = np.array([1.0, 0.7, 0.5, 0.3, 0.2])
+
+    def draw(n):
+        amps = rng.standard_normal((n, k_true)) * scale
+        return amps @ modes + rng.normal(scale=noise_sigma, size=(n, n_bands))
+
+    train = draw(4000)
+    scene = train.T  # (n_bands, n_pixels), band_axis=0
+    target = rng.standard_normal(n_bands) * 0.05
+
+    mu = trimmed_mean_spectrum(scene, trim_frac=0.0)
+    _, inv_matched = robust_lowrank_covariance(scene, rank=k_true, trim_frac=0.0)
+    _, inv_fixed = robust_lowrank_covariance(
+        scene, rank=k_true, trim_frac=0.0, regularization=1e-6
+    )
+
+    # Fresh noise-only (no target) test pixels; matched-filter statistic.
+    test = draw(5000)
+
+    def far_std(inv):
+        w = inv @ target
+        eps = (test - mu) @ w / float(target @ w)
+        return float(eps.std())
+
+    assert far_std(inv_matched) < far_std(inv_fixed)

--- a/tests/radtran/test_forward.py
+++ b/tests/radtran/test_forward.py
@@ -18,6 +18,18 @@ from plumax.radtran.forward import (
 NU_OBS = np.linspace(4100.0, 4400.0, 41)
 
 
+def test_out_of_grid_tp_raises(synthetic_lut):
+    # T grid is [220, 300] K, P grid [0.5, 1.0] atm. Out-of-grid queries make
+    # xarray's interp return all-NaN, which downstream masquerades as a "Σ not
+    # PD" error. The forward must fail here, naming the offending value.
+    nu = np.array([4300.0])
+    kw = dict(vmr=1e-6, path_length_cm=8.4e5, amf=2.0)
+    with pytest.raises(ValueError, match=r"T_K.*outside the LUT"):
+        forward_nonlinear(synthetic_lut, nu, T_K=400.0, p_atm=1.0, **kw)
+    with pytest.raises(ValueError, match=r"p_atm.*outside the LUT"):
+        forward_nonlinear(synthetic_lut, nu, T_K=280.0, p_atm=5.0, **kw)
+
+
 def test_forward_nonlinear_returns_nonneg_transmittance(synthetic_lut):
     result = forward_nonlinear(
         synthetic_lut,

--- a/tests/radtran/test_gaussx_solve.py
+++ b/tests/radtran/test_gaussx_solve.py
@@ -125,6 +125,22 @@ def test_tight_trim_frac_rejected_when_bands_exceed_kept_pixels():
         build_lowrank_covariance_operator(scene, rank=8, trim_frac=0.45)
 
 
+def test_float32_config_behavior():
+    # The low-rank covariance path silently degrades to float32 without x64, so
+    # it must raise a clear, actionable error rather than return wrong numbers.
+    # Toggle x64 off around the call (conftest force-enables it globally).
+    import jax
+
+    scene = _synthetic_scene(n_bands=4, shape=(16, 16))
+    original = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", False)
+    try:
+        with pytest.raises(RuntimeError, match=r"requires 64-bit JAX"):
+            build_lowrank_covariance_operator(scene, rank=3)
+    finally:
+        jax.config.update("jax_enable_x64", original)
+
+
 def test_rank_default_is_reasonable():
     scene = _synthetic_scene(n_bands=6, shape=(16, 16))
     cov, _ = build_lowrank_covariance_operator(scene)

--- a/tests/radtran/test_instrument.py
+++ b/tests/radtran/test_instrument.py
@@ -34,6 +34,35 @@ jax.config.update("jax_enable_x64", True)
 # ── PSF ──────────────────────────────────────────────────────────────────────
 
 
+def _measured_fwhm(kernel: np.ndarray) -> float:
+    """Full width at half maximum of a PSF kernel's central horizontal cut [px].
+
+    Linear-interpolates the half-max crossing on the central row; the kernel is
+    isotropic so the horizontal cut equals the true radial FWHM.
+    """
+    c = kernel.shape[0] // 2
+    row = np.asarray(kernel[c], dtype=float)
+    peak = row[c]
+    half = 0.5 * peak
+    xs = np.arange(kernel.shape[0]) - c
+    for i in range(c, kernel.shape[0] - 1):
+        if row[i] >= half >= row[i + 1]:
+            frac = (row[i] - half) / (row[i] - row[i + 1])
+            return 2.0 * (xs[i] + frac)
+    raise AssertionError("no half-max crossing found in the kernel row")
+
+
+@pytest.mark.parametrize("family", ["gaussian", "airy"])
+def test_psf_fwhm_honored(family):
+    # Both PSF families must produce a kernel whose measured FWHM equals the
+    # requested `fwhm_pixels`. The Airy scaling previously used the first-zero
+    # (1.22·fwhm) argument, giving ≈ 0.63× the requested FWHM.
+    fwhm = 4.0
+    build = getattr(PointSpreadFunction, family)
+    psf = build(fwhm_pixels=fwhm, kernel_size=15)
+    np.testing.assert_allclose(_measured_fwhm(psf.kernel), fwhm, rtol=0.02)
+
+
 class TestPointSpreadFunction:
     def test_gaussian_kernel_normalised(self):
         psf = PointSpreadFunction.gaussian(fwhm_pixels=2.0, kernel_size=9)

--- a/tests/radtran/test_target.py
+++ b/tests/radtran/test_target.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from plumax.radtran.config import number_density_cm3
 from plumax.radtran.target import (
@@ -94,3 +95,13 @@ def test_target_bands_length_mismatch():
     srf_stub = None  # not reached — shape check happens first
     with np.testing.assert_raises(ValueError):
         target_bands(np.zeros(10), srf_stub, np.zeros(11))  # type: ignore[arg-type]
+
+
+def test_band_outside_lut_coverage_warns(synthetic_lut, swir_srf):
+    # The LUT covers ~2222–2500 nm; the B11 band @1610 nm lies entirely outside,
+    # so its band-integrated target is silently zero-filled — must warn naming
+    # the band and the uncovered fraction, not fail silently.
+    lam = 1e7 / synthetic_lut["wavenumber"].values
+    t_hr = np.zeros_like(lam)
+    with pytest.warns(UserWarning, match=r"B11.*outside the LUT"):
+        target_bands(t_hr, swir_srf, lam)


### PR DESCRIPTION
Implements epic #22 — retrieval-stack robustness — in a single PR, closing confirmed correctness bugs and silent-failure modes across radtran, hapi_lut, and matched_filter.

## #42 — Airy PSF honors `fwhm_pixels` (P1)
The Airy argument used the first-zero scale (`1.22·fwhm`), so the kernel's measured FWHM was ≈ 0.63× the requested value — swapping `gaussian`→`airy` at equal `fwhm_pixels` silently changed the blur by ~1.6×. Now scaled by the half-max radius (`x ≈ 1.6163` at `r = fwhm/2`), matching the Gaussian's exact FWHM semantics. Added measured-FWHM tests for both families.

## #43 — gaussx_solve no longer degrades to float32 silently (P1)
The low-rank covariance path built float64 arrays that JAX silently truncates to float32 when `jax_enable_x64` is off (its default), quietly losing precision in the ill-conditioned Woodbury solve (CI masked it via a global x64 enable). It now raises a clear, actionable error when x64 is disabled, and the requirement is documented on the module.

## #44 — LUT coverage validation
- **Spectral:** `target_bands` / `build_nb_lut` warn (naming the band and uncovered fraction) when an SRF band's response reaches past the LUT wavelength range, where `np.interp` zero-fills and silently attenuates the result.
- **Thermodynamic:** `_interp_sigma` now bounds-checks `T_K` / `p_atm` against the LUT grid and raises naming the offending value, instead of returning all-NaN that surfaces downstream as a misleading "Σ not PD" error.

## #45 — HITRAN cache is range-aware
A successful fetch records its ν range in a `<gas>.range.json` sidecar; the offline cache fallback is refused when the cached range doesn't cover the request. A narrowed combined-LUT fetch (over the gas intersection) can no longer be served as a truncated line list for a wider request. Corrected the "no-ops on cache hit" docstring (HAPI's `fetch` overwrites unconditionally).

## #46 — Noise-matched covariance floor
The truncated-SVD covariance floor defaults to the **noise-matched** value — the mean of the discarded eigenvalue spectrum `mean(S[rank:]²)/N` — instead of a fixed `1e-6`, so `Σ⁻¹` weights the discarded subspace at the real sensor-noise level (SNR-optimal). Explicit override retained; dense and gaussx operator paths kept consistent. Added a false-alarm-rate comparison test.

## #47 — Robust/masked covariance + rank-deficiency guard
- Boolean exclude-`mask` on `estimate_cov_empirical` / `_shrunk` / `_lowrank` so detected plume pixels can be dropped, keeping `(μ, Σ)` consistent.
- Guard annulus (`guard_size`) on `adaptive_window_background` so a pixel's local background excludes its own core.
- `estimate_cov_lowrank` drops near-zero eigen-directions (`rank_rtol`) so a rank-deficient scene yields finite scores instead of inf/NaN from the Woodbury capacitance.

## Testing
Targeted suites green: `tests/radtran/`, `tests/matched_filter/`, `tests/hapi_lut/` (194 passed, 1 skipped), plus `tests/assimilation/` (30 passed) for cross-module safety. `ruff check .`, `ruff format --check .`, and `ty check src/plumax` clean (the one pre-existing `ty` warning in `lagrangian/inversion.py:57` is untouched).

Closes #42, #43, #44, #45, #46, #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEgZbnU2EmmhBrogbmxa9N

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEgZbnU2EmmhBrogbmxa9N)_