### PR TITLE
refactor: adopt gaussx/finitevolx primitives where plumax hand-rolled them (epic #21)

### DIFF
--- a/src/plumax/assimilation/cost.py
+++ b/src/plumax/assimilation/cost.py
@@ -97,9 +97,9 @@ def build_cost_x(
         delta_x = jnp.reshape(delta_x_flat, state_shape)
         x = x_b + delta_x
         residual = y - forward_fn(x)
-        # Prior term: ½ δxᵀ B⁻¹ δx. gaussx.solve dispatches on operator structure.
-        Binv_dx = gx.solve(background_op, delta_x_flat)
-        prior = 0.5 * jnp.dot(delta_x_flat, Binv_dx)
+        # Prior term: ½ δxᵀ B⁻¹ δx. gx.quadratic_form is xᵀ B⁻¹ x via a single
+        # structurally-dispatched solve — the same op gx.solve does, one call.
+        prior = 0.5 * gx.quadratic_form(background_op, delta_x_flat)
         obs = 0.5 * jnp.sum(R_inv * residual * residual)
         return prior + obs
 

--- a/src/plumax/lagrangian/inversion.py
+++ b/src/plumax/lagrangian/inversion.py
@@ -42,8 +42,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import gaussx as gx
 import jax
 import jax.numpy as jnp
+import lineax as lx
 
 
 def _is_traced(*values: object) -> bool:
@@ -157,24 +159,28 @@ def _blue_update(
     prior_cov: jax.Array,
     obs_var: jax.Array,
 ) -> tuple[jax.Array, jax.Array]:
-    """Solve the BLUE increment and posterior covariance via the innovation form.
+    """Solve the BLUE increment and posterior covariance via gaussx primitives.
 
     Returns ``(increment, posterior_cov)`` where
-    ``increment = B Fᵀ (F B Fᵀ + R)⁻¹ innovation`` and
-    ``posterior_cov = B − B Fᵀ (F B Fᵀ + R)⁻¹ F B``. ``R`` is diagonal, given by
-    ``obs_var``. The ``(n_obs × n_obs)`` system is solved with a Cholesky factor
-    for symmetry and speed (the efficient ordering when ``n_obs ≪ n_grid``).
+    ``increment = K · innovation`` with the Kalman gain
+    ``K = B Fᵀ (F B Fᵀ + R)⁻¹`` (:func:`gaussx.kalman_gain`), and the posterior
+    covariance is the numerically-superior **Joseph form**
+    ``(I − K F) B (I − K F)ᵀ + K R Kᵀ`` (:func:`gaussx.joseph_update`) —
+    algebraically identical to ``B − K (F B Fᵀ + R) Kᵀ`` for the exact gain but
+    guaranteed symmetric/PSD under floating-point error, so no manual
+    symmetrisation is needed. ``R`` is diagonal, given by ``obs_var``.
     """
-    bft = prior_cov @ jacobian.T  # B Fᵀ, (n_grid, n_obs)
-    s = jacobian @ bft  # F B Fᵀ, (n_obs, n_obs)
-    s = s + jnp.diag(obs_var)  # + R
-    # Symmetrise to kill round-off asymmetry before the Cholesky solve.
-    s = 0.5 * (s + s.T)
-    chol = jax.scipy.linalg.cho_factor(s, lower=True)
-    gain_t = jax.scipy.linalg.cho_solve(chol, bft.T)  # (F B Fᵀ + R)⁻¹ F B
-    increment = bft @ jax.scipy.linalg.cho_solve(chol, innovation)
-    posterior_cov = prior_cov - bft @ gain_t
-    posterior_cov = 0.5 * (posterior_cov + posterior_cov.T)
+    prior_op = lx.MatrixLinearOperator(
+        prior_cov,
+        tags=frozenset({lx.symmetric_tag, lx.positive_semidefinite_tag}),
+    )
+    gain = gx.kalman_gain(
+        prior_op,
+        lx.MatrixLinearOperator(jacobian),
+        lx.DiagonalLinearOperator(obs_var),
+    )  # K = B Fᵀ (F B Fᵀ + R)⁻¹, shape (n_grid, n_obs)
+    increment = gain @ innovation
+    posterior_cov = gx.joseph_update(prior_cov, gain, jacobian, jnp.diag(obs_var))
     return increment, posterior_cov
 
 

--- a/src/plumax/les_fvm/_vertical_ops.py
+++ b/src/plumax/les_fvm/_vertical_ops.py
@@ -109,27 +109,3 @@ def vertical_diffusion_tendency(
     tendency_interior = (flux_face[1:] - flux_face[:-1]) / dz
     out = jnp.zeros_like(concentration)
     return out.at[1:-1, :, :].set(tendency_interior)
-
-
-def zero_horizontal_ghosts(
-    field: Float[Array, "Nz Ny Nx"],
-) -> Float[Array, "Nz Ny Nx"]:
-    """Zero the four horizontal ghost faces of a 3-D field.
-
-    Useful after in-place interior updates when the caller wants the
-    ghost ring known to be zero before a BC application overwrites it.
-    """
-    out = field.at[:, 0, :].set(0.0)
-    out = out.at[:, -1, :].set(0.0)
-    out = out.at[:, :, 0].set(0.0)
-    out = out.at[:, :, -1].set(0.0)
-    return out
-
-
-def zero_vertical_ghosts(
-    field: Float[Array, "Nz Ny Nx"],
-) -> Float[Array, "Nz Ny Nx"]:
-    """Zero the top and bottom ghost slices of a 3-D field."""
-    out = field.at[0, :, :].set(0.0)
-    out = out.at[-1, :, :].set(0.0)
-    return out

--- a/src/plumax/les_fvm/dynamics.py
+++ b/src/plumax/les_fvm/dynamics.py
@@ -9,7 +9,7 @@ single pytree leaf that diffrax can JIT as ``term = ODETerm(rhs)``.
 from __future__ import annotations
 
 import equinox as eqx
-import jax.numpy as jnp
+import finitevolx as fvx
 from jaxtyping import Array, Float
 
 from plumax.les_fvm.advection import advection_tendency
@@ -102,16 +102,9 @@ class EulerianDispersionRHS(eqx.Module):
             c_diff, self.eddy_diffusivity, self.plume_grid, periodic=periodic
         )
         src = self.source(t)
-        # Keep ghost-cell entries of the tendency zero; time integration writes
-        # only to the interior and the BC pass above has already updated the
-        # ghost ring of the state.
+        # Keep ghost-cell entries of the tendency zero (finitevolX `interior`
+        # idiom, no materialised mask): the integrator writes only to the
+        # interior, and the BC pass above already updated the ghost ring of the
+        # state.
         rhs = adv + diff + src
-        return jnp.where(_interior_mask(rhs.shape, rhs.dtype), rhs, 0.0)
-
-
-def _interior_mask(shape: tuple[int, int, int], dtype) -> Float[Array, "Nz Ny Nx"]:
-    """Indicator field that is 1 on interior cells and 0 on ghost cells."""
-    _Nz, _Ny, _Nx = shape
-    mask = jnp.zeros(shape, dtype=dtype)
-    mask = mask.at[1:-1, 1:-1, 1:-1].set(1.0)
-    return mask
+        return fvx.interior(rhs[1:-1, 1:-1, 1:-1], rhs)

--- a/src/plumax/les_fvm/fourdvar.py
+++ b/src/plumax/les_fvm/fourdvar.py
@@ -421,8 +421,14 @@ def build_problem(
             raise ValueError(
                 f"build_problem: `{_name}` must be finite (contains NaN/inf)."
             )
-    # Jitter keeps the Cholesky factor PD for smooth Matérn kernels.
-    chol = jnp.linalg.cholesky(b + 1e-9 * jnp.eye(n_t))
+    # Adaptive-jitter Cholesky: gx.safe_cholesky escalates the jitter on failure
+    # (JIT-compatible), succeeding for badly-scaled Matérn priors where a fixed
+    # 1e-9 kick would not.
+    chol = gx.safe_cholesky(
+        lx.MatrixLinearOperator(
+            b, tags=frozenset({lx.symmetric_tag, lx.positive_semidefinite_tag})
+        )
+    )
 
     # Resolve obs_variance to R, the (n_t, n_obs) diagonal. A length-n_t 1-D
     # input is treated as one variance *per overpass* (R_t), so reshape it to a
@@ -662,6 +668,7 @@ def posterior_covariance(
     )
     p_chi = gx.inv(hessian_op).as_matrix()
     # Symmetrise to clean up asymmetric round-off before the congruence map.
+    # (Would be gx.symmetrize once exported — gaussx#202; manual until then.)
     p_chi = 0.5 * (p_chi + p_chi.T)
     chol = problem.prior_chol  # L with B = L Lᵀ
     p_source = chol @ p_chi @ chol.T
@@ -698,9 +705,12 @@ def laplace_sample(
     chi_star = jnp.asarray(whitened_map, dtype=float)
     post = posterior_covariance(problem, chi_star)
     n_t = chi_star.shape[0]
-    # Jitter keeps the whitened-covariance Cholesky PD against round-off.
-    chol_chi = jnp.linalg.cholesky(
-        post.whitened_covariance + 1e-12 * jnp.eye(n_t, dtype=chi_star.dtype)
+    # Adaptive-jitter Cholesky against round-off in the whitened covariance.
+    chol_chi = gx.safe_cholesky(
+        lx.MatrixLinearOperator(
+            post.whitened_covariance,
+            tags=frozenset({lx.symmetric_tag, lx.positive_semidefinite_tag}),
+        )
     )
     noise = jax.random.normal(key, (int(n_samples), n_t), dtype=chi_star.dtype)
     chi_samples = chi_star[None, :] + noise @ chol_chi.T

--- a/src/plumax/matched_filter/background.py
+++ b/src/plumax/matched_filter/background.py
@@ -263,9 +263,7 @@ def estimate_cov_lowrank(
     V = svd.components_  # shape (rank, n_bands), rows are right singular vectors
     s = svd.singular_values_  # shape (rank,)
     d = (s**2) / max(n_samples, 1)
-    base = lx.DiagonalLinearOperator(
-        jnp.asarray(tikhonov * np.ones(n_bands, dtype=float))
-    )
+    diag = jnp.asarray(tikhonov * np.ones(n_bands, dtype=float))
     # Rank-deficiency guard: drop near-zero eigen-directions so the Woodbury
     # capacitance stays finite. If none survive (e.g. a constant scene), Σ is
     # just the strictly-PD Tikhonov floor λI.
@@ -273,14 +271,11 @@ def estimate_cov_lowrank(
     keep = d > rank_rtol * d_max if d_max > 0.0 else np.zeros(d.shape, dtype=bool)
     V, d = V[keep], d[keep]
     if d.size == 0:
-        return base
+        return lx.DiagonalLinearOperator(diag)
+    # λ I + U diag(d) Uᵀ via the gaussx SVD constructor (auto-inferred
+    # symmetric/PSD tags, orthonormal-factor solve path).
     U = jnp.asarray(V.T)  # (n_bands, n_kept) — spectral directions as columns
-    return gx.LowRankUpdate(
-        base,
-        U,
-        jnp.asarray(d),
-        tags=frozenset({lx.symmetric_tag, lx.positive_semidefinite_tag}),
-    )
+    return gx.svd_low_rank_plus_diag(diag, U, jnp.asarray(d), U)
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────

--- a/src/plumax/radtran/background.py
+++ b/src/plumax/radtran/background.py
@@ -91,6 +91,88 @@ def trimmed_mean_spectrum(
     return np.asarray(trim_mean(flat, trim_frac, axis=0), dtype=float)
 
 
+def _estimate_lowrank_model(
+    radiance: np.ndarray,
+    *,
+    rank: int | None,
+    trim_frac: float,
+    regularization: float | None,
+    band_axis: int,
+    context: str,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, float]:
+    """Shared trim + truncated-SVD covariance model (single source of truth).
+
+    Centres the pixel stack with a trimmed mean, drops the extreme-energy
+    pixels, truncates the SVD to ``rank``, and picks the diagonal floor. Returns
+    ``(mu, U, d, lam)`` such that ``Σ = U diag(d) Uᵀ + lam·I``. Consumed by both
+    :func:`robust_lowrank_covariance` (which materialises Σ/Σ⁻¹) and
+    :func:`plumax.radtran.gaussx_solve.build_lowrank_covariance_operator` (which
+    wraps it in a gaussx operator) so the two paths cannot drift apart — the
+    dense-vs-operator agreement tests are only meaningful while they don't.
+
+    Parameters
+    ----------
+    radiance, band_axis
+        Radiance cube and its band axis.
+    rank
+        Truncation rank; ``None`` → ``min(n_bands - 1, 16)``.
+    trim_frac
+        Two-sided energy trim fraction in ``[0, 0.5)``.
+    regularization
+        Diagonal floor; ``None`` → noise-matched (:func:`_noise_matched_floor`).
+    context
+        Caller name, prepended to validation-error messages.
+
+    Returns
+    -------
+    mu : np.ndarray, shape ``(n_bands,)``
+    U : np.ndarray, shape ``(n_bands, rank)`` — principal directions (columns).
+    d : np.ndarray, shape ``(rank,)`` — retained covariance eigenvalues ``S_k²/N``.
+    lam : float — diagonal floor.
+    """
+    flat = _flatten_pixels(radiance, band_axis)  # (n_pixels, n_bands)
+    n_pixels, n_bands = flat.shape
+    if n_pixels < 2:
+        raise ValueError(f"{context}: need ≥ 2 pixels (got {n_pixels})")
+    if not (0.0 <= trim_frac < 0.5):
+        raise ValueError(
+            f"{context}: `trim_frac` must be in [0, 0.5) (got {trim_frac!r})"
+        )
+    if regularization is not None and regularization <= 0.0:
+        raise ValueError(f"{context}: `regularization` must be > 0.")
+    if rank is None:
+        rank = min(n_bands - 1, 16)
+    rank = max(1, min(int(rank), n_bands))
+
+    mu = trimmed_mean_spectrum(radiance, trim_frac=trim_frac, band_axis=band_axis)
+    centred = flat - mu[None, :]
+
+    # Drop the top/bottom `trim_frac` pixels by total energy so bright outliers
+    # don't dominate the SVD.
+    if trim_frac > 0.0:
+        energy = np.linalg.norm(centred, axis=1)
+        lo, hi = np.quantile(energy, [trim_frac, 1.0 - trim_frac])
+        keep = (energy >= lo) & (energy <= hi)
+        if keep.sum() < n_bands:
+            raise ValueError(
+                f"{context}: trimming left fewer pixels than bands; "
+                "reduce `trim_frac` or enlarge the scene."
+            )
+        centred = centred[keep]
+
+    # Deterministic truncated SVD (small scenes; keeps tests reproducible).
+    _, S, Vt = np.linalg.svd(centred, full_matrices=False)
+    n_kept = centred.shape[0]
+    U = Vt[:rank].T  # (n_bands, rank) — principal directions as columns
+    d = S[:rank] ** 2 / max(n_kept, 1)  # retained covariance eigenvalues
+    lam = (
+        _noise_matched_floor(S, rank, n_kept)
+        if regularization is None
+        else float(regularization)
+    )
+    return mu, U, d, lam
+
+
 def robust_lowrank_covariance(
     radiance: np.ndarray,
     *,
@@ -137,49 +219,17 @@ def robust_lowrank_covariance(
     Sigma, Sigma_inv : np.ndarray
         Symmetric PSD matrices, shape ``(n_bands, n_bands)``.
     """
-    flat = _flatten_pixels(radiance, band_axis)  # (n_pixels, n_bands)
-    n_pixels, n_bands = flat.shape
-    if n_pixels < 2:
-        raise ValueError(f"robust_lowrank_covariance: need ≥ 2 pixels (got {n_pixels})")
-    if not (0.0 <= trim_frac < 0.5):
-        raise ValueError(
-            f"robust_lowrank_covariance: `trim_frac` must be in [0, 0.5) (got {trim_frac!r})"
-        )
-    if regularization is not None and regularization <= 0.0:
-        raise ValueError("robust_lowrank_covariance: `regularization` must be > 0.")
-    if rank is None:
-        rank = min(n_bands - 1, 16)
-    rank = max(1, min(int(rank), n_bands))
-
-    mu = trimmed_mean_spectrum(radiance, trim_frac=trim_frac, band_axis=band_axis)
-    centred = flat - mu[None, :]
-
-    # Drop the top/bottom `trim_frac` pixels by total energy to keep bright
-    # outliers from dominating the SVD. This mirrors the dynamic-mode
-    # rejection in the original code but without the GMM complexity.
-    if trim_frac > 0.0:
-        energy = np.linalg.norm(centred, axis=1)
-        lo, hi = np.quantile(energy, [trim_frac, 1.0 - trim_frac])
-        keep = (energy >= lo) & (energy <= hi)
-        if keep.sum() < n_bands:
-            raise ValueError(
-                "robust_lowrank_covariance: trimming left fewer pixels than bands; "
-                "reduce `trim_frac` or enlarge the scene."
-            )
-        centred = centred[keep]
-
-    # Truncated SVD via numpy (scene is small for multispectral; for
-    # hyperspectral callers can pre-subsample). Randomised SVD would give
-    # a constant-factor speed-up but the deterministic path keeps tests
-    # reproducible.
-    _, S, Vt = np.linalg.svd(centred, full_matrices=False)
-    S_k = S[:rank]
-    V_k = Vt[:rank]  # shape (rank, n_bands); V_k.T are the principal directions.
-
-    # Σ in the top-k subspace (1 / N) · Vᵀ S² V, plus the diagonal floor λ.
-    N = centred.shape[0]
-    lam = _noise_matched_floor(S, rank, N) if regularization is None else regularization
-    Sigma = (V_k.T * (S_k**2)) @ V_k / max(N, 1) + lam * np.eye(n_bands)
+    mu, U, d, lam = _estimate_lowrank_model(
+        radiance,
+        rank=rank,
+        trim_frac=trim_frac,
+        regularization=regularization,
+        band_axis=band_axis,
+        context="robust_lowrank_covariance",
+    )
+    n_bands = mu.shape[0]
+    # Σ = U diag(d) Uᵀ + λ I (d = S_k² / N are the retained covariance eigenvalues).
+    Sigma = (U * d) @ U.T + lam * np.eye(n_bands)
 
     # Woodbury inverse for efficiency: (λI + Uᵀ D U)⁻¹ where
     #   U = V_k (rank, n_bands), D = diag(S_k² / N) (rank, rank).

--- a/src/plumax/radtran/gaussx_solve.py
+++ b/src/plumax/radtran/gaussx_solve.py
@@ -133,75 +133,26 @@ def build_lowrank_covariance_operator(
         *same* trimmed pixel stack — avoiding a subtle bias where μ drops
         outliers that Σ's trim step kept.
     """
-    gx, jnp, lx = _import_gaussx_stack()
+    gx, jnp, _ = _import_gaussx_stack()
 
-    from plumax.radtran.background import (
-        _flatten_pixels,
-        _noise_matched_floor,
-        trimmed_mean_spectrum,
+    from plumax.radtran.background import _estimate_lowrank_model
+
+    # Shared trim/SVD model — identical (μ, U, d, λ) to the dense
+    # `robust_lowrank_covariance` path, so the two cannot drift apart.
+    mu, U, d, lam = _estimate_lowrank_model(
+        radiance,
+        rank=rank,
+        trim_frac=trim_frac,
+        regularization=regularization,
+        band_axis=band_axis,
+        context="build_lowrank_covariance_operator",
     )
-
-    flat = _flatten_pixels(radiance, band_axis)  # (n_pixels, n_bands)
-    n_pixels, n_bands = flat.shape
-    if n_pixels < 2:
-        raise ValueError(
-            f"build_lowrank_covariance_operator: need ≥ 2 pixels (got {n_pixels})"
-        )
-    if not (0.0 <= trim_frac < 0.5):
-        raise ValueError(
-            f"build_lowrank_covariance_operator: `trim_frac` must be in "
-            f"[0, 0.5) (got {trim_frac!r})"
-        )
-    if regularization is not None and regularization <= 0.0:
-        raise ValueError(
-            "build_lowrank_covariance_operator: `regularization` must be > 0."
-        )
-    if rank is None:
-        rank = min(n_bands - 1, 16)
-    rank = max(1, min(int(rank), n_bands))
-
-    mu = trimmed_mean_spectrum(radiance, trim_frac=trim_frac, band_axis=band_axis)
-    centred = flat - mu[None, :]
-
-    if trim_frac > 0.0:
-        energy = np.linalg.norm(centred, axis=1)
-        lo, hi = np.quantile(energy, [trim_frac, 1.0 - trim_frac])
-        keep = (energy >= lo) & (energy <= hi)
-        if keep.sum() < n_bands:
-            raise ValueError(
-                "build_lowrank_covariance_operator: trimming left fewer "
-                "pixels than bands; reduce `trim_frac` or enlarge the scene."
-            )
-        centred = centred[keep]
-
-    _, S, Vt = np.linalg.svd(centred, full_matrices=False)
-    S_k = S[:rank]
-    V_k = Vt[:rank]  # (rank, n_bands)
-    n_kept = centred.shape[0]
-
-    # U: principal directions as columns.
-    U = jnp.asarray(V_k.T)  # (n_bands, rank)
-    d = jnp.asarray(S_k**2 / max(n_kept, 1))  # diag of U d Uᵀ
-    # Diagonal floor λ: noise-matched by default (mean of the discarded
-    # covariance eigenvalues) so Σ⁻¹ weights the discarded subspace at the true
-    # sensor-noise level; see background._noise_matched_floor. Kept identical to
-    # the dense `robust_lowrank_covariance` path so the two agree.
-    lam = (
-        _noise_matched_floor(S, rank, n_kept)
-        if regularization is None
-        else float(regularization)
-    )
-    # Base: λ · I as an explicit *diagonal* operator so gaussx.solve picks up the
-    # fast per-element inverse path. A naive ``λ * IdentityLinearOperator(...)``
-    # would build a ScaledOperator that gaussx does not specialise and that would
-    # compute the dense inverse instead.
-    base = lx.DiagonalLinearOperator(lam * jnp.ones(n_bands, dtype=jnp.float64))
-
-    cov = gx.LowRankUpdate(
-        base,
-        U,
-        d,
-        tags=frozenset({lx.symmetric_tag, lx.positive_semidefinite_tag}),
+    n_bands = mu.shape[0]
+    # λ I + U diag(d) Uᵀ via the gaussx SVD constructor: it infers the
+    # symmetric/PSD tags and takes the orthonormal-factor solve path (U's columns
+    # are SVD directions), so we don't hand-maintain tags or a diagonal base.
+    cov = gx.svd_low_rank_plus_diag(
+        jnp.full(n_bands, lam), jnp.asarray(U), jnp.asarray(d), jnp.asarray(U)
     )
     return cov, mu
 

--- a/tests/lagrangian/test_inversion.py
+++ b/tests/lagrangian/test_inversion.py
@@ -123,6 +123,30 @@ def test_linear_inversion_reduces_variance():
     assert np.min(np.linalg.eigvalsh(p)) > -1e-8
 
 
+def test_posterior_cov_psd_ill_conditioned():
+    # Near-collinear observation rows + an extremely tight R make the innovation
+    # system S = F B Fᵀ + R badly ill-conditioned. The difference-form update
+    # (B − K S Kᵀ) can go slightly indefinite there; the gaussx Joseph form keeps
+    # the posterior covariance symmetric PSD.
+    rng = np.random.default_rng(3)
+    n_grid, n_obs = 10, 6
+    coords = np.linspace(0.0, 1000.0, n_grid)
+    b = np.asarray(matern32_covariance(coords, variance=1.0, length_scale=400.0))
+    base_row = rng.uniform(0.0, 1.0, size=n_grid)
+    f = np.stack([base_row + 1e-8 * rng.standard_normal(n_grid) for _ in range(n_obs)])
+    y = f @ np.full(n_grid, 1.2)
+    r = observation_covariance(
+        np.full(n_obs, 1e-12)
+    )  # extremely tight → ill-conditioned
+    post = linear_gaussian_inversion(
+        f, y, prior_mean=np.full(n_grid, 1.0), prior_cov=b, obs_variance=r
+    )
+    p = np.asarray(post.covariance)
+    np.testing.assert_allclose(p, p.T, atol=1e-9)
+    min_eig = float(np.min(np.linalg.eigvalsh(p)))
+    assert min_eig > -1e-8, f"posterior covariance not PSD: min eig {min_eig}"
+
+
 def test_linear_inversion_shape_validation():
     coords, f, q_true = _toy_problem()
     n_obs, n_grid = f.shape

--- a/tests/les_fvm/test_fourdvar.py
+++ b/tests/les_fvm/test_fourdvar.py
@@ -115,6 +115,36 @@ def test_cost_and_grad_are_finite():
     assert np.all(np.isfinite(np.asarray(g)))
 
 
+def test_badly_scaled_prior_cholesky():
+    # A prior covariance with a slightly-negative eigenvalue (round-off scale):
+    # the old fixed-1e-9 jitter still leaves the Cholesky NaN, but gx.safe_cholesky
+    # escalates the jitter (1e-8 → …) and returns a finite lower-triangular factor.
+    fwd = _forward()
+    n_t = fwd.save_times.shape[0]
+    rng = np.random.default_rng(0)
+    q = np.linalg.qr(rng.standard_normal((n_t, n_t)))[0]
+    eigs = np.linspace(1.0, 0.1, n_t)
+    eigs[-1] = -5e-9  # just indefinite — fixed 1e-9 jitter cannot rescue it
+    b = jnp.asarray(q @ np.diag(eigs) @ q.T)
+
+    # The old path fails on this prior.
+    l_fixed = np.asarray(jnp.linalg.cholesky(b + 1e-9 * jnp.eye(n_t)))
+    assert np.isnan(l_fixed).any()
+
+    # build_problem (now via safe_cholesky) yields a finite factor.
+    y = fwd.predict(jnp.array([0.0, 1.0, 1.0, 0.5, 0.5]))
+    prob = build_problem(
+        forward=fwd,
+        observations=y,
+        prior_mean=jnp.full(n_t, 0.5),
+        prior_covariance=b,
+        obs_variance=1e-6,
+    )
+    chol = np.asarray(prob.prior_chol)
+    assert np.all(np.isfinite(chol))
+    np.testing.assert_allclose(chol, np.tril(chol), atol=1e-12)
+
+
 def test_cost_minimised_at_truth_in_whitened_space():
     fwd = _forward()
     q_true = jnp.array([0.0, 1.0, 1.0, 0.5, 0.5])

--- a/tests/les_fvm/test_vertical_ops.py
+++ b/tests/les_fvm/test_vertical_ops.py
@@ -8,8 +8,6 @@ import numpy as np
 from plumax.les_fvm._vertical_ops import (
     vertical_advection_tendency,
     vertical_diffusion_tendency,
-    zero_horizontal_ghosts,
-    zero_vertical_ghosts,
 )
 
 
@@ -94,21 +92,3 @@ def test_vertical_diffusion_handles_field_kappa():
     t_scalar = vertical_diffusion_tendency(c, kappa_z=kappa_scalar, dz=dz)
     t_field = vertical_diffusion_tendency(c, kappa_z=kappa_field, dz=dz)
     np.testing.assert_allclose(np.asarray(t_scalar), np.asarray(t_field), atol=1e-6)
-
-
-def test_zero_ghost_helpers_do_not_touch_interior():
-    field = jnp.arange(6 * 4 * 4, dtype=jnp.float32).reshape(6, 4, 4)
-    interior = np.asarray(field)[1:-1, 1:-1, 1:-1]
-
-    zeroed_h = zero_horizontal_ghosts(field)
-    np.testing.assert_allclose(np.asarray(zeroed_h)[1:-1, 1:-1, 1:-1], interior)
-    # Horizontal ghost rings are zero.
-    assert float(jnp.abs(zeroed_h[:, 0, :]).max()) == 0.0
-    assert float(jnp.abs(zeroed_h[:, -1, :]).max()) == 0.0
-    assert float(jnp.abs(zeroed_h[:, :, 0]).max()) == 0.0
-    assert float(jnp.abs(zeroed_h[:, :, -1]).max()) == 0.0
-
-    zeroed_v = zero_vertical_ghosts(field)
-    np.testing.assert_allclose(np.asarray(zeroed_v)[1:-1, 1:-1, 1:-1], interior)
-    assert float(jnp.abs(zeroed_v[0]).max()) == 0.0
-    assert float(jnp.abs(zeroed_v[-1]).max()) == 0.0

--- a/tests/matched_filter/test_core.py
+++ b/tests/matched_filter/test_core.py
@@ -77,11 +77,10 @@ def test_dense_and_lowrank_agree_on_same_cov(rng):
     )
     import gaussx as gx
 
-    cov_lr = gx.LowRankUpdate(
-        lx.DiagonalLinearOperator(jnp.asarray(tikhonov * np.ones(B))),
-        jnp.asarray(V),
-        jnp.asarray(d),
-        tags=frozenset({lx.symmetric_tag, lx.positive_semidefinite_tag}),
+    # V is a general (non-orthonormal) factor here, so use the general
+    # low_rank_plus_diag constructor (diag + V diag(d) Vᵀ), not the SVD variant.
+    cov_lr = gx.low_rank_plus_diag(
+        jnp.asarray(tikhonov * np.ones(B)), jnp.asarray(V), jnp.asarray(d)
     )
     target = jnp.asarray(rng.standard_normal(B))
     pixel = jnp.asarray(rng.standard_normal(B))


### PR DESCRIPTION
Implements epic #21 — replace hand-rolled linear-algebra and grid utilities with the upstream primitives plumax is built on (gaussx, finitevolx). Each swap is behaviour-preserving except where the upstream primitive is strictly more robust; existing agreement / FD-gradient / round-trip tests pin the equivalence.

Every gaussx/finitevolx symbol used here was verified present in the installed packages before adoption.

## #36 — `gx.svd_low_rank_plus_diag`
`radtran/gaussx_solve` and `matched_filter/background` build the low-rank covariance via `gx.svd_low_rank_plus_diag` (auto-inferred symmetric/PSD tags, orthonormal-factor solve path) instead of a hand-tagged `gx.LowRankUpdate` over a manual diagonal base. Deleted the factually-wrong "a `regularization * IdentityLinearOperator` would build a ScaledOperator gaussx doesn't specialise" comment. The non-orthonormal factor in `test_core` uses the general `gx.low_rank_plus_diag`.

## #37 — Shared trim/SVD model
Factored the ~40 duplicated lines into `background._estimate_lowrank_model`, consumed by both the dense `robust_lowrank_covariance` and the operator `build_lowrank_covariance_operator`, so the dense-vs-operator agreement tests can't silently drift. Preserves the epic-#22 noise-matched floor and validation semantics.

## #38 — `gx.safe_cholesky`
`les_fvm/fourdvar` uses `gx.safe_cholesky` at both Cholesky sites (adaptive, JIT-compatible jitter escalation) instead of a fixed `1e-9` kick that fails for badly-scaled Matérn priors. Added `test_badly_scaled_prior_cholesky` (a prior the fixed jitter can't rescue).

**Note:** the two `0.5·(P+Pᵀ)` symmetrisation sites stay manual — `gx.symmetrize` is *not* exported by the installed gaussx (the audit assumed it). Filed upstream as jejjohnson/gaussx#202 and referenced in a comment; will swap once it lands.

## #39 — `gx.kalman_gain` + `gx.joseph_update`
`lagrangian/inversion._blue_update` uses `gx.kalman_gain` and the Joseph-form `gx.joseph_update` (guaranteed symmetric/PSD) instead of the difference form `B − K S Kᵀ` + manual re-symmetrisation. Added `test_posterior_cov_psd_ill_conditioned` (near-collinear rows + tight R, where the difference form can go indefinite).

## #40 — `gx.quadratic_form`
`assimilation/cost.build_cost_x` expresses the prior term as `0.5·gx.quadratic_form(B, δx)` (one structurally-dispatched solve).

## #41 — `finitevolx.interior` + dead-code removal
`les_fvm/dynamics` zeros the RHS ghost ring with `finitevolx.interior` (no materialised mask). Deleted the dead `_vertical_ops.zero_horizontal_ghosts` / `zero_vertical_ghosts` helpers (no `src/` caller) and their tests.

## Testing
Verified the affected suites pass: `tests/radtran/` + `tests/matched_filter/` (dense-vs-operator agreement), `tests/lagrangian/test_inversion.py` (BLUE equivalence + new PSD test), `tests/assimilation/` (cost FD/value), and `tests/les_fvm/` (dynamics ghost-ring, both `safe_cholesky` sites incl. posterior/laplace/solve_4dvar, new badly-scaled-prior test). `ruff check .`, `ruff format --check .`, and `ty check src/plumax` clean (the one pre-existing `ty` warning in `inversion.py:57` is untouched).

Closes #36, #37, #38, #39, #40, #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEgZbnU2EmmhBrogbmxa9N

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEgZbnU2EmmhBrogbmxa9N)_